### PR TITLE
Allow plusses in annotation values

### DIFF
--- a/src/__tests__/value-object-parser-test.ts
+++ b/src/__tests__/value-object-parser-test.ts
@@ -69,7 +69,7 @@ describe('ValueObjectParser', function() {
     it('parses a value object with two properties and lots of custom ' +
        'information that is valid', function() {
       const valueFileContents = '%library name=RMSomethingLibrary\n' +
-                              '%type name=Foo library=Bar file=NSObject+Baz canForwardDeclare=false\n'
+                              '%type name=Foo library=Bar file=NSObject+Baz canForwardDeclare=false\n' +
                               '%type name=Scumbag library=Steve\n' +
                               'RMSomething {\n' +
                               '  %import file=RMSomeOtherFile library=RMCustomLibrary\n' +

--- a/src/__tests__/value-object-parser-test.ts
+++ b/src/__tests__/value-object-parser-test.ts
@@ -69,7 +69,7 @@ describe('ValueObjectParser', function() {
     it('parses a value object with two properties and lots of custom ' +
        'information that is valid', function() {
       const valueFileContents = '%library name=RMSomethingLibrary\n' +
-                              '%type name=Foo library=Bar file=Baz canForwardDeclare=false\n' +
+                              '%type name=Foo library=Bar file=NSObject+Baz canForwardDeclare=false\n'
                               '%type name=Scumbag library=Steve\n' +
                               'RMSomething {\n' +
                               '  %import file=RMSomeOtherFile library=RMCustomLibrary\n' +
@@ -88,7 +88,7 @@ describe('ValueObjectParser', function() {
             properties: {
               name: 'Foo',
               library: 'Bar',
-              file: 'Baz',
+              file: 'NSObject+Baz',
               canForwardDeclare: 'false'
             }
           },
@@ -139,7 +139,7 @@ describe('ValueObjectParser', function() {
           {
             name:'Foo',
             library:Maybe.Just<string>('Bar'),
-            file:Maybe.Just<string>('Baz'),
+            file:Maybe.Just<string>('NSObject+Baz'),
             canForwardDeclare: false,
           },
           {

--- a/src/js/object-mona-parser/object-parser-common.js
+++ b/src/js/object-mona-parser/object-parser-common.js
@@ -56,7 +56,7 @@ function quotedText() {
 
 function unquotedTextTerminatingWithSpace() {
   return mona.sequence(function(s) {
-    const text = s(mona.text(mona.or(mona.alphanum(), mona.string('_'))));
+    const text = s(mona.text(mona.or(mona.alphanum(), mona.string('_'), mona.string('+'))));
     s(mona.spaces());
     return mona.value(text);
   });


### PR DESCRIPTION
Currently it's not possible to use annotation with plus in it. It can be problematic if for example the type we are using was declared in file that contains plus (category).

As an example:
```
%type name=Foo library=Bar file=NSObject+Baz
```