### PR TITLE
Set correct values for IO in writeBuiltOnRevisionPromise in build.js

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -212,8 +212,8 @@ function writeBuiltOnRevisionPromise(revision) {
       return Promise.reject({
         value: null,
         error: error,
-        stdout: res.stdout,
-        stderr: res.stderr,
+        stdout: error && error.stdout,
+        stderr: error && error.stderr,
       });
     }
   );


### PR DESCRIPTION
The parameter `res` was not defined in the method `onRejected`, use `error.stdout` and `error.stderr` instead.
