### PR TITLE
Adding annotations to AlgebraicType and AlgebraicSubtypeAttribute

### DIFF
--- a/src/__tests__/algebraic-type-parser-test.ts
+++ b/src/__tests__/algebraic-type-parser-test.ts
@@ -24,6 +24,7 @@ describe('AlgebraicTypeParser', function() {
       const actualResult:Either.Either<Error.Error[], AlgebraicType.Type> = AlgebraicTypeParser.parse(fileContents);
 
       const expectedADT:AlgebraicType.Type = {
+        annotations: {},
         name: 'RMSomething',
         comments: [],
         includes: [],
@@ -35,6 +36,7 @@ describe('AlgebraicTypeParser', function() {
             comments: [],
             attributes: [
             {
+              annotations: {},
               name: 'someUnsignedInt',
               nullability:ObjC.Nullability.Inherited(),
               type: {
@@ -59,6 +61,7 @@ describe('AlgebraicTypeParser', function() {
       const actualResult:Either.Either<Error.Error[], AlgebraicType.Type> = AlgebraicTypeParser.parse(fileContents);
 
       const expectedADT:AlgebraicType.Type = {
+        annotations: {},
         name: 'RMSomething',
         comments: [],
         includes: [],
@@ -67,6 +70,7 @@ describe('AlgebraicTypeParser', function() {
         subtypes: [
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
             {
+              annotations: {},
               name: 'rmObjectProperty',
               nullability:ObjC.Nullability.Inherited(),
               type: {
@@ -94,6 +98,16 @@ describe('AlgebraicTypeParser', function() {
       const actualResult:Either.Either<Error.Error[], AlgebraicType.Type> = AlgebraicTypeParser.parse(fileContents);
 
       const expectedADT:AlgebraicType.Type = {
+        annotations: {
+          type: [
+            {
+              "properties": {
+                "name": "Scumbag",
+                "library": "Steve"
+              }
+            }
+          ]
+        },
         name: 'RMSomething',
         comments: [],
         includes: [],
@@ -109,6 +123,16 @@ describe('AlgebraicTypeParser', function() {
         subtypes: [
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
             {
+              annotations: {
+                import: [
+                  {
+                    "properties": {
+                      "file": "RMSomeOtherFile",
+                      "library": "RMCustomLibrary"
+                    }
+                  }
+                ]
+              },
               name: 'rmObjectProperty',
               nullability:ObjC.Nullability.Inherited(),
               type: {
@@ -139,6 +163,15 @@ describe('AlgebraicTypeParser', function() {
                          '}';
       const actualResult:Either.Either<Error.Error[], AlgebraicType.Type> = AlgebraicTypeParser.parse(fileContents);
       const expectedADT:AlgebraicType.Type = {
+        annotations: {
+          library: [
+              {
+                "properties": {
+                  "name": "RMSomethingLibrary"
+                }
+              }
+            ]
+        },
         name: 'RMSomething',
         comments: ['My warm something'],
         includes: ['A'],
@@ -151,6 +184,16 @@ describe('AlgebraicTypeParser', function() {
             comments: [],
             attributes: [
               {
+                annotations: {
+                  import: [
+                      {
+                        "properties": {
+                          "file": "RMSomeOtherFile",
+                          "library": "RMCustomLibrary"
+                        }
+                      }
+                    ]
+                },
                 comments: [],
                 name: 'someBlah',
                 nullability:ObjC.Nullability.Inherited(),
@@ -163,6 +206,7 @@ describe('AlgebraicTypeParser', function() {
                 }
               },
               {
+                annotations: {},
                 comments: [],
                 name: 'someValue',
                 nullability:ObjC.Nullability.Inherited(),
@@ -192,6 +236,7 @@ describe('AlgebraicTypeParser', function() {
                          '}';
       const actualResult:Either.Either<Error.Error[], AlgebraicType.Type> = AlgebraicTypeParser.parse(fileContents);
       const expectedADT:AlgebraicType.Type = {
+        annotations: {},
         name: 'RMSomething',
         comments: [],
         includes: [],
@@ -204,6 +249,13 @@ describe('AlgebraicTypeParser', function() {
             comments: [],
             attributes: [
               {
+                annotations: {
+                  nullable: [
+                      {
+                        "properties": {}
+                      }
+                    ]
+                },
                 comments: [],
                 name: 'someBlah',
                 nullability:ObjC.Nullability.Nullable(),
@@ -216,6 +268,13 @@ describe('AlgebraicTypeParser', function() {
                 }
               },
               {
+                annotations: {
+                  nonnull: [
+                      {
+                        "properties": {}
+                      }
+                    ]
+                },
                 comments: [],
                 name: 'someValue',
                 nullability:ObjC.Nullability.Nonnull(),

--- a/src/__tests__/plugins/algebraic-type-function-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-function-matching-test.ts
@@ -22,6 +22,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
   describe('#blockTypes', function() {
     it('returns block types for matching an algebraic type', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -35,6 +36,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someString',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -47,6 +49,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someUnsignedInteger',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -62,6 +65,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'singleAttributeSubtype',
             nullability:ObjC.Nullability.Inherited(),
             comments: [],
@@ -125,6 +129,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
   describe('#instanceMethods', function() {
     it('returns an instance method for matching the subtypes of an algebraic type', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -138,6 +143,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someString',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -150,6 +156,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someUnsignedInteger',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -165,6 +172,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'singleAttributeSubtype',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),

--- a/src/__tests__/plugins/algebraic-type-initialization-test.ts
+++ b/src/__tests__/plugins/algebraic-type-initialization-test.ts
@@ -23,6 +23,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
   describe('#imports', function() {
     it('includes a public import for Foundation/Foundation.h', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Foo',
         includes: [],
         excludes: [],
@@ -50,6 +51,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
 
     it('includes a private import for its own header', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Foo',
         includes: [],
         excludes: [],
@@ -77,6 +79,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
 
     it('includes the public imports for some of its attributes', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -90,6 +93,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFoo',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -102,6 +106,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someBool',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -117,6 +122,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'singleAttributeSubtype',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -160,6 +166,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
     it('includes for an attribute that is an NSObject but does not have a ' +
        'specified library and the algebraic type is in a library', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -169,6 +176,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
         subtypes: [
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'someFoo',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -197,6 +205,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
     it('returns a single class method when there is one subtype ' +
        'with no attributes', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Foo',
         includes: [],
         excludes: [],
@@ -241,6 +250,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
     it('returns two class methods when there are two subtypes ' +
        'with some attributes', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -254,6 +264,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someString',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -266,6 +277,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someUnsignedInteger',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -281,6 +293,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'singleAttributeSubtype',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -372,6 +385,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
     it('returns internal properties for storing the subtypes attributes as well ' +
        'as the type', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -385,6 +399,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someString',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -397,6 +412,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someUnsignedInteger',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -412,6 +428,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'singleAttributeSubtype',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -476,6 +493,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
   describe('#enumerations', function() {
     it('returns an enumeration for its subtypes', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Foo',
         includes: [],
         excludes: [],
@@ -489,6 +507,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someString',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -501,6 +520,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someUnsignedInteger',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -516,6 +536,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'singleAttributeSubtype',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -547,6 +568,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
   describe('#validationErrors', function() {
     it('returns no validation errors when there are no attributes on the provided subtypes', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Foo',
         includes: [],
         excludes: [],
@@ -574,6 +596,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
 
     it('returns a validation error when there are two subtypes with the same name', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -587,6 +610,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFoo',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -606,6 +630,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'anotherFoo',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -630,6 +655,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
 
     it('returns a validation error when there are two single attribute subtypes with the same name', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -639,6 +665,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
         subtypes: [
         AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
         {
+          annotations: {},
           name: 'singleAttributeSubtype',
           comments: [],
           nullability:ObjC.Nullability.Inherited(),
@@ -652,6 +679,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
         }),
         AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
         {
+          annotations: {},
           name: 'singleAttributeSubtype',
           comments: [],
           nullability:ObjC.Nullability.Inherited(),
@@ -674,6 +702,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
 
     it('returns a validation error when one single attribute subtype and one named subtype have same name', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -687,6 +716,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
           comments: [],
           attributes: [
             {
+              annotations: {},
               name: 'someFoo',
               comments: [],
               nullability:ObjC.Nullability.Inherited(),
@@ -702,6 +732,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
         }),
         AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
         {
+          annotations: {},
           name: 'someSubtype',
           comments: [],
           nullability:ObjC.Nullability.Inherited(),

--- a/src/__tests__/plugins/algebraic-type-templated-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-templated-matching-test.ts
@@ -23,6 +23,7 @@ describe('Plugins.AlgebraicTypeTemplatedMatching', function() {
   describe('#additionalFiles', function() {
     it ('returns a header and implementation for matching on an algebraic type', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'RMTest',
         includes: [],
         excludes: [],
@@ -36,6 +37,7 @@ describe('Plugins.AlgebraicTypeTemplatedMatching', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someString',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -48,6 +50,7 @@ describe('Plugins.AlgebraicTypeTemplatedMatching', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someUnsignedInteger',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -69,6 +72,7 @@ describe('Plugins.AlgebraicTypeTemplatedMatching', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'coolSingleAttributeSubtype',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),

--- a/src/__tests__/plugins/coding-test.ts
+++ b/src/__tests__/plugins/coding-test.ts
@@ -684,6 +684,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
   describe('#instanceMethods', function() {
     it('returns two instance methods which will encode and decode two values when called', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         typeLookups:[],
@@ -697,6 +698,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someString',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -709,6 +711,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someUnsignedInteger',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -724,6 +727,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'coolSingleAttributeSubtype',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -823,6 +827,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
     it('returns four constants referencing to the key for coding when the algebraic type ' +
       'has two subtypes with three cumulative attributes', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         typeLookups:[],
@@ -836,6 +841,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someString',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -848,6 +854,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someUnsignedInteger',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -863,6 +870,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'coolSingleAttributeSubtype',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -928,6 +936,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
   describe('#validationErrors', function() {
     it('returns no validation errors when there are no attributes on the provided subtypes', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Foo',
         includes: [],
         typeLookups:[],
@@ -955,6 +964,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
 
     it('returns a validation error when there is an attribute with an unknown type', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         typeLookups:[],
@@ -968,6 +978,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFoo',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -992,6 +1003,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
 
     it('returns two validation errors when there are two attributes with unknown types', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         typeLookups:[],
@@ -1005,6 +1017,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFoo',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -1023,6 +1036,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFerr',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -1048,6 +1062,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
 
     it('returns a validation error when there is an attribute with an unknown underlying type', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         typeLookups:[],
@@ -1061,6 +1076,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFerr',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),

--- a/src/__tests__/plugins/description-test.ts
+++ b/src/__tests__/plugins/description-test.ts
@@ -1240,6 +1240,7 @@ describe('AlgebraicTypePlugins.Description', function() {
   describe('#imports', function() {
     it('correctly finds imports for description functions that require them', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -1253,6 +1254,7 @@ describe('AlgebraicTypePlugins.Description', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someString',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -1265,6 +1267,7 @@ describe('AlgebraicTypePlugins.Description', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someUnsignedInteger',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -1280,6 +1283,7 @@ describe('AlgebraicTypePlugins.Description', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'coolSingleAttributeRectSubtype',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -1307,6 +1311,7 @@ describe('AlgebraicTypePlugins.Description', function() {
     it('returns an instance method which will output a different description ' +
        'depending on which subtype is being represented', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -1320,6 +1325,7 @@ describe('AlgebraicTypePlugins.Description', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someString',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -1332,6 +1338,7 @@ describe('AlgebraicTypePlugins.Description', function() {
                 }
               },
               {
+                annotations: {},
                 name: 'someUnsignedInteger',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -1347,6 +1354,7 @@ describe('AlgebraicTypePlugins.Description', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'coolSingleAttributeBoolSubtype',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -1399,6 +1407,7 @@ describe('AlgebraicTypePlugins.Description', function() {
   describe('#validationErrors', function() {
     it('returns no validation errors when there are no attributes on the provided subtypes', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Foo',
         includes: [],
         excludes: [],
@@ -1425,6 +1434,7 @@ describe('AlgebraicTypePlugins.Description', function() {
     });
     it('returns a validation error when there is an attribute with an unknown type', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -1438,6 +1448,7 @@ describe('AlgebraicTypePlugins.Description', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFoo',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -1461,6 +1472,7 @@ describe('AlgebraicTypePlugins.Description', function() {
     });
     it('returns two validation errors when there are two attributes with unknown types', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -1474,6 +1486,7 @@ describe('AlgebraicTypePlugins.Description', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFoo',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -1489,6 +1502,7 @@ describe('AlgebraicTypePlugins.Description', function() {
           }),
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'someFerr',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -1511,6 +1525,7 @@ describe('AlgebraicTypePlugins.Description', function() {
     });
     it('returns a validation error when there is an attribute with an unknown underlying type', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         excludes: [],
@@ -1524,6 +1539,7 @@ describe('AlgebraicTypePlugins.Description', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFerr',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),

--- a/src/__tests__/plugins/equality-test.ts
+++ b/src/__tests__/plugins/equality-test.ts
@@ -1160,6 +1160,7 @@ describe('AlgebraicTypePlugins.Equality', function() {
   describe('#validationErrors', function() {
     it('returns no validation errors when there are no attributes on the provided subtypes', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Foo',
         includes: [],
         typeLookups:[],
@@ -1188,6 +1189,7 @@ describe('AlgebraicTypePlugins.Equality', function() {
 
     it('returns a validation error when there is an attribute with an unknown type', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         typeLookups:[],
@@ -1197,6 +1199,7 @@ describe('AlgebraicTypePlugins.Equality', function() {
         subtypes: [
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'someFoo',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),
@@ -1219,6 +1222,7 @@ describe('AlgebraicTypePlugins.Equality', function() {
 
     it('returns two validation errors when there are two attributes with unknown types', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         typeLookups:[],
@@ -1232,6 +1236,7 @@ describe('AlgebraicTypePlugins.Equality', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFoo',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -1251,6 +1256,7 @@ describe('AlgebraicTypePlugins.Equality', function() {
             comments: [],
             attributes: [
               {
+                annotations: {},
                 name: 'someFerr',
                 comments: [],
                 nullability:ObjC.Nullability.Inherited(),
@@ -1276,6 +1282,7 @@ describe('AlgebraicTypePlugins.Equality', function() {
 
     it('returns a validation error when there is an attribute with an unknown underlying type', function() {
       const algebraicType:AlgebraicType.Type = {
+        annotations: {},
         name: 'Test',
         includes: [],
         typeLookups:[],
@@ -1285,6 +1292,7 @@ describe('AlgebraicTypePlugins.Equality', function() {
         subtypes: [
           AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
           {
+            annotations: {},
             name: 'someFerr',
             comments: [],
             nullability:ObjC.Nullability.Inherited(),

--- a/src/algebraic-type-parser.ts
+++ b/src/algebraic-type-parser.ts
@@ -43,6 +43,7 @@ function subtypeAttributeTypeFromParsedAttribtueType(type:ObjectMonaParser.Parse
 
 function subtypeAttributeFromParseResultAttribute(attribute:ObjectMonaParser.ParsedAttribute):AlgebraicType.SubtypeAttribute {
   return {
+    annotations:ObjectGenerationParsingUtils.foundAnnotationFromParsedAnnotations(attribute.annotations),
     name:attribute.name,
     comments:attribute.comments,
     type:subtypeAttributeTypeFromParsedAttribtueType(attribute.type, attribute.annotations),
@@ -62,6 +63,7 @@ function subtypeFromParsedSubtype(subtype:ObjectMonaParser.AlgebraicParsedSubtyp
 
 function algebraicTypeFromParsedType(type:ObjectMonaParser.AlgebraicParsedType):AlgebraicType.Type {
   return {
+    annotations:ObjectGenerationParsingUtils.foundAnnotationFromParsedAnnotations(type.annotations),
     comments:type.comments,
     name:type.typeName,
     includes:type.includes,

--- a/src/algebraic-type.ts
+++ b/src/algebraic-type.ts
@@ -23,6 +23,7 @@ export interface SubtypeAttributeType {
 }
 
 export interface SubtypeAttribute {
+  annotations: {[name:string]: ObjectGeneration.Annotation[];};
   comments:string[];
   name:string;
   nullability:ObjC.Nullability;
@@ -70,6 +71,7 @@ export class Subtype {
 }
 
 export interface Type {
+  annotations: {[name:string]: ObjectGeneration.Annotation[];};
   comments:string[];
   includes:string[];
   excludes:string[];

--- a/src/algebraic-types.ts
+++ b/src/algebraic-types.ts
@@ -75,6 +75,7 @@ function parseValues(either:Either.Either<Error.Error[], ReadFileUtils.UnparsedO
 
 function typeInformationContainingDefaultIncludes(typeInformation:AlgebraicType.Type, defaultIncludes:List.List<string>):AlgebraicType.Type {
   return {
+    annotations:typeInformation.annotations,
     comments: typeInformation.comments,
     excludes: typeInformation.excludes,
     includes: PluginInclusionUtils.includesContainingDefaultIncludes(typeInformation.includes, typeInformation.excludes, defaultIncludes),

--- a/src/annotation-utils.ts
+++ b/src/annotation-utils.ts
@@ -8,12 +8,12 @@
  */
 
 import Maybe = require('./maybe');
-import ValueObject = require('./value-object');
+import ObjectGeneration = require('./object-generation');
 
-export function annotationValuesWithName(annotations:{[name:string]: ValueObject.Annotation[];}, annotationName:string):Maybe.Maybe<ValueObject.Annotation[]> {
+export function annotationValuesWithName(annotations:{[name:string]: ObjectGeneration.Annotation[];}, annotationName:string):Maybe.Maybe<ObjectGeneration.Annotation[]> {
   if (annotations && annotations[annotationName]) {
-    return Maybe.Just<ValueObject.Annotation[]>(annotations[annotationName]);
+    return Maybe.Just<ObjectGeneration.Annotation[]>(annotations[annotationName]);
   } else {
-    return Maybe.Nothing<ValueObject.Annotation[]>();
+    return Maybe.Nothing<ObjectGeneration.Annotation[]>();
   }
 }

--- a/src/object-generation-parsing-utils.ts
+++ b/src/object-generation-parsing-utils.ts
@@ -136,11 +136,11 @@ export function typeLookupsFromRawAnnotations(annotations:{[name:string]: {[key:
   );
 }
 
-export function typeLookupsFromAnnotations(annotations:Maybe.Maybe<ValueObject.Annotation[]>):Either.Either<Error.Error[], ObjectGeneration.TypeLookup[]> {
+export function typeLookupsFromAnnotations(annotations:Maybe.Maybe<ObjectGeneration.Annotation[]>):Either.Either<Error.Error[], ObjectGeneration.TypeLookup[]> {
   return Maybe.match(
-    function(annotations:ValueObject.Annotation[]) {
+    function(annotations:ObjectGeneration.Annotation[]) {
       const annotationProperties = annotations.map(
-        function(annotation:ValueObject.Annotation):{[key:string]: string} {
+        function(annotation:ObjectGeneration.Annotation):{[key:string]: string} {
           return annotation.properties;
         }
       );
@@ -151,4 +151,16 @@ export function typeLookupsFromAnnotations(annotations:Maybe.Maybe<ValueObject.A
     },
     annotations
   );
+}
+
+export function foundAnnotationFromParsedAnnotations(parsedAnnotations:{[name:string]: {[key:string]: string}[]}):{[key:string]:ObjectGeneration.Annotation[]} {
+  const foundAnnotations:{[key:string]:ObjectGeneration.Annotation[]} = {};
+  for (const parsedAnnotationName in parsedAnnotations) {
+    foundAnnotations[parsedAnnotationName] = parsedAnnotations[parsedAnnotationName].map(function(parsedInstance:{[key:string]: string}):ObjectGeneration.Annotation {
+      return {
+        properties:parsedInstance,
+      };
+    });
+  }
+  return foundAnnotations;
 }

--- a/src/object-generation.ts
+++ b/src/object-generation.ts
@@ -16,3 +16,7 @@ export interface TypeLookup {
   file:Maybe.Maybe<string>;
   canForwardDeclare:boolean;
 }
+
+export interface Annotation {
+  properties: {[name:string]:string};
+}

--- a/src/value-object-parser.ts
+++ b/src/value-object-parser.ts
@@ -43,7 +43,7 @@ function foundAttributeTypeFromParsedAttributeType(type:ObjectMonaParser.ParsedA
 
 function foundAttributeFromParseResultAttribute(attribute:ObjectMonaParser.ParsedAttribute):ValueObject.Attribute {
   return {
-   annotations:foundAnnotationFromParsedAnnotations(attribute.annotations),
+   annotations:ObjectGenerationParsingUtils.foundAnnotationFromParsedAnnotations(attribute.annotations),
    comments:attribute.comments,
    name:attribute.name,
    nullability:ObjectGenerationParsingUtils.nullabilityFromParseResultAnnotations(attribute.annotations),
@@ -51,21 +51,9 @@ function foundAttributeFromParseResultAttribute(attribute:ObjectMonaParser.Parse
   };
 }
 
-function foundAnnotationFromParsedAnnotations(parsedAnnotations:{[name:string]: {[key:string]: string}[]}):{[key:string]:ValueObject.Annotation[]} {
-  const foundAnnotations:{[key:string]:ValueObject.Annotation[]} = {};
-  for (const parsedAnnotationName in parsedAnnotations) {
-    foundAnnotations[parsedAnnotationName] = parsedAnnotations[parsedAnnotationName].map(function(parsedInstance:{[key:string]: string}):ValueObject.Annotation {
-      return {
-        properties:parsedInstance,
-      };
-    });
-  }
-  return foundAnnotations;
-}
-
 function foundTypeFromParsedType(foundType:ObjectMonaParser.ValueObjectParsedType):ValueObject.Type {
   return {
-    annotations:foundAnnotationFromParsedAnnotations(foundType.annotations),
+    annotations:ObjectGenerationParsingUtils.foundAnnotationFromParsedAnnotations(foundType.annotations),
     attributes:foundType.attributes.map(foundAttributeFromParseResultAttribute),
     comments:foundType.comments,
     typeName:foundType.typeName,

--- a/src/value-object.ts
+++ b/src/value-object.ts
@@ -23,19 +23,15 @@ export interface AttributeType {
 }
 
 export interface Attribute {
-  annotations: {[name:string] : Annotation[];};
+  annotations: {[name:string] : ObjectGeneration.Annotation[];};
   comments: string[];
   name: string;
   nullability: ObjC.Nullability;
   type: AttributeType;
 }
 
-export interface Annotation {
-  properties: {[name:string]:string};
-}
-
 export interface Type {
-  annotations: {[name:string]: Annotation[];};
+  annotations: {[name:string]: ObjectGeneration.Annotation[];};
   attributes: Attribute[];
   comments: string[];
   excludes: string[];


### PR DESCRIPTION
ValueObjects parse arbitrary user generated annotations so that they can be used for plugins. AlgebraicTypes lack this feature.

This diff adds support for annotations on AlgebraicTypes.