### PR TITLE
Add forward declaration for type name if attribute references it

### DIFF
--- a/src/__tests__/plugins/algebraic-type-initialization-test.ts
+++ b/src/__tests__/plugins/algebraic-type-initialization-test.ts
@@ -753,4 +753,84 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
       expect(errors).toEqualJSON(expectedErrors);
     });
   });
+
+  describe('#forwardDeclarations', function() {
+    it('returns a forward declaration when the same type being generated ' +
+       'is being used as an attribute type', function() {
+      const algebraicType:AlgebraicType.Type = {
+        annotations: {},
+        name: 'Test',
+        includes: [],
+        excludes: [],
+        typeLookups:[],
+        libraryName: Maybe.Nothing<string>(),
+        comments: [],
+        subtypes: [
+        AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
+        {
+          name: 'SomeSubtype',
+          comments: [],
+          attributes: [
+            {
+              annotations: {},
+              name: 'someFoo',
+              comments: [],
+              nullability:ObjC.Nullability.Inherited(),
+              type: {
+                name: 'Test',
+                reference: 'Test *',
+                libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
+                fileTypeIsDefinedIn: Maybe.Nothing<string>(),
+                underlyingType: Maybe.Nothing<string>()
+              }
+            }
+          ]
+        })
+        ]
+      };
+      const forwardDeclarations:ObjC.ForwardDeclaration[] = AlgebraicTypePlugin.forwardDeclarations(algebraicType);
+      const expectedForwardDeclarations:ObjC.ForwardDeclaration[] = [
+        ObjC.ForwardDeclaration.ForwardClassDeclaration('Test')
+      ];
+      expect(forwardDeclarations).toEqualJSON(expectedForwardDeclarations);
+    });
+
+    it('returns no forward declarations when the same type being generated ' +
+       'is not being referenced in a subtype', function() {
+      const algebraicType:AlgebraicType.Type = {
+        annotations: {},
+        name: 'Test',
+        includes: [],
+        excludes: [],
+        typeLookups:[],
+        libraryName: Maybe.Nothing<string>(),
+        comments: [],
+        subtypes: [
+        AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
+        {
+          name: 'SomeSubtype',
+          comments: [],
+          attributes: [
+            {
+              annotations: {},
+              name: 'someFoo',
+              comments: [],
+              nullability:ObjC.Nullability.Inherited(),
+              type: {
+                name: 'AnotherTest',
+                reference: 'AnotherTest *',
+                libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
+                fileTypeIsDefinedIn: Maybe.Nothing<string>(),
+                underlyingType: Maybe.Nothing<string>()
+              }
+            }
+          ]
+        })
+        ]
+      };
+      const forwardDeclarations:ObjC.ForwardDeclaration[] = AlgebraicTypePlugin.forwardDeclarations(algebraicType);
+      const expectedForwardDeclarations:ObjC.ForwardDeclaration[] = [];
+      expect(forwardDeclarations).toEqualJSON(expectedForwardDeclarations);
+    });
+  });
 });

--- a/src/__tests__/plugins/immutable-properties-test.ts
+++ b/src/__tests__/plugins/immutable-properties-test.ts
@@ -1381,4 +1381,70 @@ describe('Plugins.ImmutableProperties', function() {
       expect(modifiers).toContain(ObjC.PropertyModifier.Nullable());
     });
   });
+
+  describe('#forwardDeclarations', function() {
+    it('returns a forward declaration when the same type being generated ' +
+       'is being used as an attribute type', function() {
+      const valueType:ValueObject.Type = {
+        annotations: {},
+        attributes: [
+          {
+            annotations: {},
+            comments: [],
+            name:'value',
+            nullability:ObjC.Nullability.Inherited(),
+            type: {
+              fileTypeIsDefinedIn:Maybe.Nothing<string>(),
+              libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
+              name:'RMSomething',
+              reference: 'RMSomething *',
+              underlyingType:Maybe.Nothing<string>()
+            }
+          }
+        ],
+        comments: [],
+        typeLookups:[],
+        excludes: [],
+        includes: [],
+        typeName: 'RMSomething',
+        libraryName: Maybe.Nothing<string>()
+      };
+      const forwardDeclarations:ObjC.ForwardDeclaration[] = Plugin.forwardDeclarations(valueType);
+      const expectedForwardDeclarations:ObjC.ForwardDeclaration[] = [
+        ObjC.ForwardDeclaration.ForwardClassDeclaration('RMSomething')
+      ];
+      expect(forwardDeclarations).toEqualJSON(expectedForwardDeclarations);
+    });
+
+    it('returns no forward declarations when the same type being generated ' +
+       'is not being referenced in a subtype', function() {
+      const valueType:ValueObject.Type = {
+        annotations: {},
+        attributes: [
+          {
+            annotations: {},
+            comments: [],
+            name:'value',
+            nullability:ObjC.Nullability.Inherited(),
+            type: {
+              fileTypeIsDefinedIn:Maybe.Nothing<string>(),
+              libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
+              name:'Foo',
+              reference: 'Foo *',
+              underlyingType:Maybe.Nothing<string>()
+            }
+          }
+        ],
+        comments: [],
+        typeLookups:[],
+        excludes: [],
+        includes: [],
+        typeName: 'RMSomething',
+        libraryName: Maybe.Nothing<string>()
+      };
+      const forwardDeclarations:ObjC.ForwardDeclaration[] = Plugin.forwardDeclarations(valueType);
+      const expectedForwardDeclarations:ObjC.ForwardDeclaration[] = [];
+      expect(forwardDeclarations).toEqualJSON(expectedForwardDeclarations);
+    });
+  });
 });


### PR DESCRIPTION
We need a forward declaration if we encounter a type that contains itself:

```
Value {
  Value *foo
}
```