### PR TITLE
Before invoking block in adt matcher - do nil check

### DIFF
--- a/features/algebraic-type-forward-declaration.feature
+++ b/features/algebraic-type-forward-declaration.feature
@@ -149,15 +149,21 @@ Feature: Outputting forward declarations in Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeRandomSubtype: {
-            someRandomSubtypeMatchHandler();
+            if (someRandomSubtypeMatchHandler) {
+              someRandomSubtypeMatchHandler();
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }

--- a/features/algebraic-types-coding.feature
+++ b/features/algebraic-types-coding.feature
@@ -171,11 +171,15 @@ Feature: Outputting Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }

--- a/features/algebraic-types-cplusplus.feature
+++ b/features/algebraic-types-cplusplus.feature
@@ -145,15 +145,21 @@ Feature: Outputting ObjC++ Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeRandomSubtype: {
-            someRandomSubtypeMatchHandler();
+            if (someRandomSubtypeMatchHandler) {
+              someRandomSubtypeMatchHandler();
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }

--- a/features/algebraic-types.feature
+++ b/features/algebraic-types.feature
@@ -172,19 +172,27 @@ Feature: Outputting Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeRandomSubtype: {
-            someRandomSubtypeMatchHandler();
+            if (someRandomSubtypeMatchHandler) {
+              someRandomSubtypeMatchHandler();
+            }
             break;
           }
           case _SimpleADTSubtypesSomeAttributeSubtype: {
-            someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            if (someAttributeSubtypeMatchHandler) {
+              someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }
@@ -327,11 +335,15 @@ Feature: Outputting Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }
@@ -489,15 +501,21 @@ Feature: Outputting Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeRandomSubtype: {
-            someRandomSubtypeMatchHandler();
+            if (someRandomSubtypeMatchHandler) {
+              someRandomSubtypeMatchHandler();
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }

--- a/features/generics.feature
+++ b/features/generics.feature
@@ -206,11 +206,15 @@ Feature: Outputting Objects With Generic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_namesToAges);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_namesToAges);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeAttributeSubtype: {
-            someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            if (someAttributeSubtypeMatchHandler) {
+              someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            }
             break;
           }
         }

--- a/features/nullability.feature
+++ b/features/nullability.feature
@@ -255,19 +255,27 @@ Feature: Outputting Objects With Nullability Annotations
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeRandomSubtype: {
-            someRandomSubtypeMatchHandler();
+            if (someRandomSubtypeMatchHandler) {
+              someRandomSubtypeMatchHandler();
+            }
             break;
           }
           case _SimpleADTSubtypesSomeAttributeSubtype: {
-            someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            if (someAttributeSubtypeMatchHandler) {
+              someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }

--- a/src/__tests__/plugins/algebraic-type-function-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-function-matching-test.ts
@@ -194,11 +194,15 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
         code: [
           'switch (_subtype) {',
           '  case _TestSubtypesSomeSubtype: {',
-          '    someSubtypeMatchHandler(_someSubtype_someString, _someSubtype_someUnsignedInteger);',
+          '    if (someSubtypeMatchHandler) {',
+          '      someSubtypeMatchHandler(_someSubtype_someString, _someSubtype_someUnsignedInteger);',
+          '    }',
           '    break;',
           '  }',
           '  case _TestSubtypesSingleAttributeSubtype: {',
-          '    singleAttributeSubtypeMatchHandler(_singleAttributeSubtype);',
+          '    if (singleAttributeSubtypeMatchHandler) {',
+          '      singleAttributeSubtypeMatchHandler(_singleAttributeSubtype);',
+          '    }',
           '    break;',
           '  }',
           '}'

--- a/src/plugins/algebraic-type-function-matching.ts
+++ b/src/plugins/algebraic-type-function-matching.ts
@@ -27,12 +27,16 @@ function instanceMethodKeywordsForMatchingSubtypesOfAlgebraicType(algebraicType:
   return [firstKeyword].concat(additionalKeywords);
 }
 
-function blockInvocationForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype):string[] {
-  return [AlgebraicTypeUtils.blockParameterNameForMatchMethodFromSubtype(subtype) + '(' + AlgebraicTypeUtils.attributesFromSubtype(subtype).map(FunctionUtils.pApplyf2(subtype, AlgebraicTypeUtils.valueAccessorForInternalPropertyForAttribute)).join(', ') + ');'];
+function blockInvocationWithNilCheckForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype):string[] {
+  return ['if (' + AlgebraicTypeUtils.blockParameterNameForMatchMethodFromSubtype(subtype) + ') {', StringUtils.indent(2)(blockInvocationForSubtype(algebraicType, subtype)), '}'];
+}
+
+function blockInvocationForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype):string {
+  return AlgebraicTypeUtils.blockParameterNameForMatchMethodFromSubtype(subtype) + '(' + AlgebraicTypeUtils.attributesFromSubtype(subtype).map(FunctionUtils.pApplyf2(subtype, AlgebraicTypeUtils.valueAccessorForInternalPropertyForAttribute)).join(', ') + ');';
 }
 
 function matcherCodeForAlgebraicType(algebraicType:AlgebraicType.Type):string[] {
-  return AlgebraicTypeUtils.codeForSwitchingOnSubtypeWithSubtypeMapper(algebraicType, AlgebraicTypeUtils.valueAccessorForInternalPropertyStoringSubtype(), blockInvocationForSubtype);
+  return AlgebraicTypeUtils.codeForSwitchingOnSubtypeWithSubtypeMapper(algebraicType, AlgebraicTypeUtils.valueAccessorForInternalPropertyStoringSubtype(), blockInvocationWithNilCheckForSubtype);
 }
 
 function instanceMethodForMatchingSubtypesOfAlgebraicType(algebraicType:AlgebraicType.Type):ObjC.Method {


### PR DESCRIPTION
Let's consider nil checking for blocks in `match` function.

Tested with unit and acceptance tests.
