### PR TITLE
Allow type lookups for types being declared for use in generics

### DIFF
--- a/src/__tests__/plugins/algebraic-type-initialization-test.ts
+++ b/src/__tests__/plugins/algebraic-type-initialization-test.ts
@@ -77,6 +77,42 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
       expect(imports).toContain(expectedImport);
     });
 
+    it('does not include a public import for its own type when it is included ' +
+       'in a type lookup', function() {
+      const algebraicType:AlgebraicType.Type = {
+        annotations: {},
+        name: 'Foo',
+        includes: [],
+        excludes: [],
+        typeLookups:[
+          {
+            name: 'Foo',
+            library: Maybe.Nothing<string>(),
+            file: Maybe.Nothing<string>(),
+            canForwardDeclare: true
+          }
+        ],
+        libraryName: Maybe.Nothing<string>(),
+        comments: [],
+        subtypes: [
+          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
+          {
+            name: 'ASubType',
+            comments: [],
+            attributes: []
+          })
+        ]
+      };
+
+      const imports:ObjC.Import[] = AlgebraicTypePlugin.imports(algebraicType);
+      const expectedImport:ObjC.Import = {
+        library:Maybe.Nothing<string>(),
+        file:'Foo.h',
+        isPublic:true
+      };
+      expect(imports).not.toContain(expectedImport);
+    });
+
     it('includes the public imports for some of its attributes', function() {
       const algebraicType:AlgebraicType.Type = {
         annotations: {},
@@ -779,6 +815,53 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
               type: {
                 name: 'Test',
                 reference: 'Test *',
+                libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
+                fileTypeIsDefinedIn: Maybe.Nothing<string>(),
+                underlyingType: Maybe.Nothing<string>()
+              }
+            }
+          ]
+        })
+        ]
+      };
+      const forwardDeclarations:ObjC.ForwardDeclaration[] = AlgebraicTypePlugin.forwardDeclarations(algebraicType);
+      const expectedForwardDeclarations:ObjC.ForwardDeclaration[] = [
+        ObjC.ForwardDeclaration.ForwardClassDeclaration('Test')
+      ];
+      expect(forwardDeclarations).toEqualJSON(expectedForwardDeclarations);
+    });
+
+    it('returns a forward declaration when the same type being generated ' +
+       'is being used in a type lookup', function() {
+      const algebraicType:AlgebraicType.Type = {
+        annotations: {},
+        name: 'Test',
+        includes: [],
+        excludes: [],
+        typeLookups:[
+          {
+            name: 'Test',
+            library: Maybe.Nothing<string>(),
+            file: Maybe.Nothing<string>(),
+            canForwardDeclare: true
+          }
+        ],
+        libraryName: Maybe.Nothing<string>(),
+        comments: [],
+        subtypes: [
+        AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
+        {
+          name: 'SomeSubtype',
+          comments: [],
+          attributes: [
+            {
+              annotations: {},
+              name: 'someFoo',
+              comments: [],
+              nullability:ObjC.Nullability.Inherited(),
+              type: {
+                name: 'Foo',
+                reference: 'Foo *',
                 libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                 fileTypeIsDefinedIn: Maybe.Nothing<string>(),
                 underlyingType: Maybe.Nothing<string>()

--- a/src/__tests__/plugins/immutable-properties-test.ts
+++ b/src/__tests__/plugins/immutable-properties-test.ts
@@ -352,6 +352,35 @@ describe('Plugins.ImmutableProperties', function() {
       });
     });
 
+    it('does not include a public import for itself when it is provided with ' +
+       'a type lookup for itself', function() {
+      const valueType:ValueObject.Type = {
+        annotations: {},
+        attributes: [],
+        comments: [],
+        typeLookups:[
+          {
+            name:'RMSomething',
+            library:Maybe.Nothing<string>(),
+            file:Maybe.Nothing<string>(),
+            canForwardDeclare: true,
+          }
+        ],
+        excludes: [],
+        includes: [],
+        typeName: 'RMSomething',
+        libraryName: Maybe.Just('RMSomeLibrary')
+      };
+
+      const actualImports = Plugin.imports(valueType);
+
+      expect(actualImports).not.toContain({
+        file:'RMSomething.h',
+        isPublic:true,
+        library:Maybe.Just<string>('RMSomeLibrary')
+      });
+    });
+
     it('includes for an attribute that is an NSObject but does not have a ' +
        'specified library and the value object is in a library', function() {
       const valueType:ValueObject.Type = {
@@ -1404,6 +1433,46 @@ describe('Plugins.ImmutableProperties', function() {
         ],
         comments: [],
         typeLookups:[],
+        excludes: [],
+        includes: [],
+        typeName: 'RMSomething',
+        libraryName: Maybe.Nothing<string>()
+      };
+      const forwardDeclarations:ObjC.ForwardDeclaration[] = Plugin.forwardDeclarations(valueType);
+      const expectedForwardDeclarations:ObjC.ForwardDeclaration[] = [
+        ObjC.ForwardDeclaration.ForwardClassDeclaration('RMSomething')
+      ];
+      expect(forwardDeclarations).toEqualJSON(expectedForwardDeclarations);
+    });
+
+    it('returns a forward declaration when the same type being generated ' +
+       'is being used in a type lookup', function() {
+      const valueType:ValueObject.Type = {
+        annotations: {},
+        attributes: [
+          {
+            annotations: {},
+            comments: [],
+            name:'value',
+            nullability:ObjC.Nullability.Inherited(),
+            type: {
+              fileTypeIsDefinedIn:Maybe.Nothing<string>(),
+              libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
+              name:'Foo',
+              reference: 'Foo *',
+              underlyingType:Maybe.Nothing<string>()
+            }
+          }
+        ],
+        comments: [],
+        typeLookups:[
+          {
+            name:'RMSomething',
+            library:Maybe.Nothing<string>(),
+            file:Maybe.Nothing<string>(),
+            canForwardDeclare: true,
+          }
+        ],
         excludes: [],
         includes: [],
         typeName: 'RMSomething',


### PR DESCRIPTION
#15 

There's a fair amount of duplication here but I think that's indicative of a smell of how we have the plugins set up currently. The more I think about it, the more I think we should extract the forward declare and import support for both value types and algebraic types to the same plugin that's separate from the initialization support for each different type