### PR TITLE
Mark initializer arguments as __unsafe_unretained

### DIFF
--- a/features/assume-nonnull.feature
+++ b/features/assume-nonnull.feature
@@ -26,7 +26,7 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
       @property (nonatomic, readonly, copy) NSString *aString;
       @property (nonatomic, readonly, copy, nullable) NSString *bString;
 
-      - (instancetype)initWithAString:(NSString *)aString bString:(nullable NSString *)bString;
+      - (instancetype)initWithAString:(__unsafe_unretained NSString *)aString bString:(nullable __unsafe_unretained NSString *)bString;
 
       @end
 
@@ -40,7 +40,7 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
 
       @implementation RMFoo
 
-      - (instancetype)initWithAString:(NSString *)aString bString:(nullable NSString *)bString
+      - (instancetype)initWithAString:(__unsafe_unretained NSString *)aString bString:(nullable __unsafe_unretained NSString *)bString
       {
         if ((self = [super init])) {
           _aString = [aString copy];

--- a/features/coding.feature
+++ b/features/coding.feature
@@ -27,7 +27,7 @@ Feature: Outputting Value Objects With Coded Values
       @property (nonatomic, readonly) NSInteger likeCount;
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings;
 
       @end
 
@@ -54,7 +54,7 @@ Feature: Outputting Value Objects With Coded Values
         return self;
       }
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings
       {
         if ((self = [super init])) {
           _doesUserLike = doesUserLike;

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -99,7 +99,7 @@ Feature: Outputting Value Objects With A Custom Plugin
       @property (nonatomic, readonly) NSInteger likeCount;
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings;
 
       @end
 
@@ -110,7 +110,7 @@ Feature: Outputting Value Objects With A Custom Plugin
 
       @implementation RMPage
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings
       {
         if ((self = [super init])) {
           _doesUserLike = doesUserLike;

--- a/features/cplusplus.feature
+++ b/features/cplusplus.feature
@@ -39,7 +39,7 @@ Feature: Outputting C++ Value Objects
       @property (nonatomic, readonly) NSInteger likeCount;
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings;
 
       @end
 
@@ -50,7 +50,7 @@ Feature: Outputting C++ Value Objects
 
       @implementation RMPage
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings
       {
         if ((self = [super init])) {
           _doesUserLike = doesUserLike;

--- a/features/forward-declaration.feature
+++ b/features/forward-declaration.feature
@@ -43,7 +43,7 @@ Feature: Outputting Value Objects With Forward Declarations
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
       @property (nonatomic, readonly, copy) RMProxy *proxy;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(__unsafe_unretained RMProxy *)proxy;
 
       @end
 
@@ -55,7 +55,7 @@ Feature: Outputting Value Objects With Forward Declarations
 
       @implementation RMPage
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(__unsafe_unretained RMProxy *)proxy
       {
         if ((self = [super init])) {
           _doesUserLike = doesUserLike;
@@ -161,7 +161,7 @@ Feature: Outputting Value Objects With Forward Declarations
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
       @property (nonatomic, readonly, copy) Foo *foo;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings foo:(Foo *)foo;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings foo:(__unsafe_unretained Foo *)foo;
 
       @end
 
@@ -176,7 +176,7 @@ Feature: Outputting Value Objects With Forward Declarations
 
       @implementation RMPage
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings foo:(Foo *)foo
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings foo:(__unsafe_unretained Foo *)foo
       {
         if ((self = [super init])) {
           _doesUserLike = doesUserLike;

--- a/features/generics.feature
+++ b/features/generics.feature
@@ -21,7 +21,7 @@ Feature: Outputting Objects With Generic Types
 
       @property (nonatomic, readonly, copy) NSDictionary<NSString *, NSNumber *> *namesToAges;
 
-      - (instancetype)initWithNamesToAges:(NSDictionary<NSString *, NSNumber *> *)namesToAges;
+      - (instancetype)initWithNamesToAges:(__unsafe_unretained NSDictionary<NSString *, NSNumber *> *)namesToAges;
 
       @end
 
@@ -32,7 +32,7 @@ Feature: Outputting Objects With Generic Types
 
       @implementation RMPage
 
-      - (instancetype)initWithNamesToAges:(NSDictionary<NSString *, NSNumber *> *)namesToAges
+      - (instancetype)initWithNamesToAges:(__unsafe_unretained NSDictionary<NSString *, NSNumber *> *)namesToAges
       {
         if ((self = [super init])) {
           _namesToAges = [namesToAges copy];

--- a/features/nullability.feature
+++ b/features/nullability.feature
@@ -25,7 +25,7 @@ Feature: Outputting Objects With Nullability Annotations
       @property (nonatomic, readonly, copy, nullable) NSString *name;
       @property (nonatomic, readonly, copy, nonnull) NSString *identifier;
 
-      - (instancetype)initWithName:(nullable NSString *)name identifier:(nonnull NSString *)identifier;
+      - (instancetype)initWithName:(nullable __unsafe_unretained NSString *)name identifier:(nonnull __unsafe_unretained NSString *)identifier;
 
       @end
 
@@ -36,7 +36,7 @@ Feature: Outputting Objects With Nullability Annotations
 
       @implementation RMPage
 
-      - (instancetype)initWithName:(nullable NSString *)name identifier:(nonnull NSString *)identifier
+      - (instancetype)initWithName:(nullable __unsafe_unretained NSString *)name identifier:(nonnull __unsafe_unretained NSString *)identifier
       {
         if ((self = [super init])) {
           _name = [name copy];

--- a/features/value_object.feature
+++ b/features/value_object.feature
@@ -48,7 +48,7 @@ Feature: Outputting Value Objects
       @property (nonatomic, readonly, unsafe_unretained) Class someClass;
       @property (nonatomic, readonly, copy) dispatch_block_t someBlock;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(uint32_t)numberOfRatings someType:(RMSomeType *)someType someClass:(Class)someClass someBlock:(dispatch_block_t)someBlock;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(uint32_t)numberOfRatings someType:(__unsafe_unretained RMSomeType *)someType someClass:(Class)someClass someBlock:(dispatch_block_t)someBlock;
 
       @end
 
@@ -59,7 +59,7 @@ Feature: Outputting Value Objects
 
       @implementation RMPage
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(uint32_t)numberOfRatings someType:(RMSomeType *)someType someClass:(Class)someClass someBlock:(dispatch_block_t)someBlock
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(uint32_t)numberOfRatings someType:(__unsafe_unretained RMSomeType *)someType someClass:(Class)someClass someBlock:(dispatch_block_t)someBlock
       {
         if ((self = [super init])) {
           _doesUserLike = doesUserLike;
@@ -165,7 +165,7 @@ Feature: Outputting Value Objects
       @property (nonatomic, readonly) CGFloat countIconWidth;
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings;
 
       @end
 
@@ -179,7 +179,7 @@ Feature: Outputting Value Objects
 
       @implementation RMPage
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(__unsafe_unretained NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings
       {
         if ((self = [super init])) {
           _doesUserLike = doesUserLike;

--- a/src/__tests__/plugins/immutable-properties-test.ts
+++ b/src/__tests__/plugins/immutable-properties-test.ts
@@ -83,7 +83,7 @@ describe('Plugins.ImmutableProperties', function() {
               name:'initWithValue',
               argument: Maybe.Just({
                 name:'value',
-                modifiers: [],
+                modifiers: [ObjC.KeywordArgumentModifier.UnsafeUnretained()],
                 type: {
                   name:'NSString',
                   reference: 'NSString *'
@@ -188,7 +188,7 @@ describe('Plugins.ImmutableProperties', function() {
               name:'initWithValue',
               argument: Maybe.Just({
                 name:'value',
-                modifiers: [],
+                modifiers: [ObjC.KeywordArgumentModifier.UnsafeUnretained()],
                 type: {
                   name:'NSString',
                   reference: 'NSString *'
@@ -210,7 +210,7 @@ describe('Plugins.ImmutableProperties', function() {
               name:'value3',
               argument: Maybe.Just({
                 name:'value3',
-                modifiers: [],
+                modifiers: [ObjC.KeywordArgumentModifier.UnsafeUnretained()],
                 type: {
                   name:'RMAnotherSomething',
                   reference: 'RMAnotherSomething *'
@@ -221,7 +221,7 @@ describe('Plugins.ImmutableProperties', function() {
               name:'value4',
               argument: Maybe.Just({
                 name:'value4',
-                modifiers: [],
+                modifiers: [ObjC.KeywordArgumentModifier.UnsafeUnretained()],
                 type: {
                   name:'id',
                   reference: 'id'

--- a/src/objc-renderer.ts
+++ b/src/objc-renderer.ts
@@ -143,7 +143,8 @@ function toPropertyString(property:ObjC.Property):string {
 function toKeywordArgumentModifierString(argumentModifier:ObjC.KeywordArgumentModifier):string {
   return argumentModifier.match(
     returnString('nonnull'),
-    returnString('nullable')
+    returnString('nullable'),
+    returnString('__unsafe_unretained')
   );
 }
 

--- a/src/objc.ts
+++ b/src/objc.ts
@@ -55,6 +55,7 @@ export interface Import {
 enum KeywordArgumentModifierType {
   nonnull,
   nullable,
+  unsafe_unretained,
 }
 
 export class KeywordArgumentModifier {
@@ -71,12 +72,18 @@ export class KeywordArgumentModifier {
     return new KeywordArgumentModifier(KeywordArgumentModifierType.nullable);
   }
 
-  match<T>(nonnull:() => T, nullable:() => T) {
+  static UnsafeUnretained() {
+    return new KeywordArgumentModifier(KeywordArgumentModifierType.unsafe_unretained);
+  }
+
+  match<T>(nonnull:() => T, nullable:() => T, unsafe_unretained: () => T) {
     switch(this.modifierType) {
       case KeywordArgumentModifierType.nonnull:
         return nonnull();
       case KeywordArgumentModifierType.nullable:
         return nullable();
+      case KeywordArgumentModifierType.unsafe_unretained:
+        return unsafe_unretained();
     }
   }
 }

--- a/src/plugins/immutable-properties.ts
+++ b/src/plugins/immutable-properties.ts
@@ -21,10 +21,21 @@ import ObjectGeneration = require('../object-generation');
 import ValueObject = require('../value-object');
 import ValueObjectCodeUtils = require('../value-object-code-utils');
 
+function arcConstructorModifiersForAttribute(attribute:ValueObject.Attribute): ObjC.KeywordArgumentModifier[] {
+  const type = ValueObjectCodeUtils.computeTypeOfAttribute(attribute);
+  if (type === null) {
+    return [];
+  }
+  if (type.name === 'id' || type.name === 'NSObject') {
+     return [ObjC.KeywordArgumentModifier.UnsafeUnretained()];
+  }
+  return [];
+}
+
 function keywordArgumentFromAttribute(attribute:ValueObject.Attribute):Maybe.Maybe<ObjC.KeywordArgument> {
   return Maybe.Just({
     name:attribute.name,
-    modifiers: ObjCNullabilityUtils.keywordArgumentModifiersForNullability(attribute.nullability),
+    modifiers: ObjCNullabilityUtils.keywordArgumentModifiersForNullability(attribute.nullability).concat(arcConstructorModifiersForAttribute(attribute)),
     type: {
       name:attribute.type.name,
       reference:attribute.type.reference


### PR DESCRIPTION
This prevents ARC from retaining and releasing said arguments unnecessarily. (Apparently, it does so because it has to be conservative: http://stackoverflow.com/questions/10310441/why-does-arc-retain-method-arguments)