### PR TITLE
Add autocomplete fix

### DIFF
--- a/features/algebraic-type-templated-matching.feature
+++ b/features/algebraic-type-templated-matching.feature
@@ -31,9 +31,10 @@ Feature: Outputting Algebraic Types With Templated Matching
       #import "SimpleADT.h"
       #import <memory>
 
-      namespace SimpleADTMatching {
-        template <typename T>
-        extern T match(SimpleADT *simpleADT, T(^firstSubtypeMatchHandler)(NSString *firstValue, NSUInteger secondValue), T(^someRandomSubtypeMatchHandler)(), T(^someAttributeSubtypeMatchHandler)(NSUInteger someAttributeSubtype), T(^secondSubtypeMatchHandler)(BOOL something)) {
+      template <typename T>
+      struct SimpleADTMatcher {
+      
+        static T match(SimpleADT *simpleADT, T(^firstSubtypeMatchHandler)(NSString *firstValue, NSUInteger secondValue), T(^someRandomSubtypeMatchHandler)(), T(^someAttributeSubtypeMatchHandler)(NSUInteger someAttributeSubtype), T(^secondSubtypeMatchHandler)(BOOL something)) {
           NSCAssert(simpleADT != nil, @"The ADT object simpleADT is nil");
           __block std::shared_ptr<T> result;
 
@@ -56,8 +57,7 @@ Feature: Outputting Algebraic Types With Templated Matching
           [simpleADT matchFirstSubtype:matchFirstSubtype someRandomSubtype:matchSomeRandomSubtype someAttributeSubtype:matchSomeAttributeSubtype secondSubtype:matchSecondSubtype];
           return *result;
         }
-        template <typename T>
-        extern T match(T(^firstSubtypeMatchHandler)(NSString *firstValue, NSUInteger secondValue), T(^someRandomSubtypeMatchHandler)(), T(^someAttributeSubtypeMatchHandler)(NSUInteger someAttributeSubtype), T(^secondSubtypeMatchHandler)(BOOL something), SimpleADT *simpleADT) {
+        static T match(T(^firstSubtypeMatchHandler)(NSString *firstValue, NSUInteger secondValue), T(^someRandomSubtypeMatchHandler)(), T(^someAttributeSubtypeMatchHandler)(NSUInteger someAttributeSubtype), T(^secondSubtypeMatchHandler)(BOOL something), SimpleADT *simpleADT) {
           NSCAssert(simpleADT != nil, @"The ADT object simpleADT is nil");
           __block std::shared_ptr<T> result;
 
@@ -80,7 +80,7 @@ Feature: Outputting Algebraic Types With Templated Matching
           [simpleADT matchFirstSubtype:matchFirstSubtype someRandomSubtype:matchSomeRandomSubtype someAttributeSubtype:matchSomeAttributeSubtype secondSubtype:matchSecondSubtype];
           return *result;
         }
-      }
+      };
 
       """
    And the file "project/values/SimpleADTTemplatedMatchingHelpers.mm" should contain:

--- a/src/__tests__/objc-renderer-test.ts
+++ b/src/__tests__/objc-renderer-test.ts
@@ -215,6 +215,7 @@ describe('ObjCRenderer', function() {
             nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -422,6 +423,7 @@ describe('ObjCRenderer', function() {
             nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -624,6 +626,7 @@ describe('ObjCRenderer', function() {
             nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -782,6 +785,7 @@ describe('ObjCRenderer', function() {
             nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -893,6 +897,7 @@ describe('ObjCRenderer', function() {
             nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -968,6 +973,7 @@ describe('ObjCRenderer', function() {
             nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -1077,6 +1083,7 @@ describe('ObjCRenderer', function() {
             nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -1149,6 +1156,7 @@ describe('ObjCRenderer', function() {
           nullability: ObjC.ClassNullability.default
         }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -1246,6 +1254,7 @@ describe('ObjCRenderer', function() {
           nullability: ObjC.ClassNullability.default
         }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -1311,6 +1320,7 @@ describe('ObjCRenderer', function() {
             nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -1390,6 +1400,7 @@ describe('ObjCRenderer', function() {
           nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -1474,6 +1485,7 @@ describe('ObjCRenderer', function() {
           nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -1565,6 +1577,7 @@ describe('ObjCRenderer', function() {
             nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -1606,6 +1619,7 @@ describe('ObjCRenderer', function() {
         functions: [],
         diagnosticIgnores:[],
         classes: [],
+        structs: [],
         namespaces: [
           {
             name: 'Something',
@@ -1831,6 +1845,7 @@ describe('ObjCRenderer', function() {
             nullability: ObjC.ClassNullability.default
           }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -1993,6 +2008,7 @@ describe('ObjCRenderer', function() {
           nullability: ObjC.ClassNullability.default
         }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -2101,6 +2117,7 @@ describe('ObjCRenderer', function() {
           nullability: ObjC.ClassNullability.default
         }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -2176,6 +2193,7 @@ describe('ObjCRenderer', function() {
           nullability: ObjC.ClassNullability.default
         }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -2224,6 +2242,7 @@ describe('ObjCRenderer', function() {
         functions: [],
         diagnosticIgnores:[],
         classes: [],
+        structs: [],
         namespaces: []
       };
 
@@ -2293,6 +2312,7 @@ describe('ObjCRenderer', function() {
         functions: [],
         diagnosticIgnores:[],
         classes: [],
+        structs: [],
         namespaces: []
       };
 
@@ -2351,6 +2371,7 @@ describe('ObjCRenderer', function() {
         functions: [],
         diagnosticIgnores:[],
         classes: [],
+        structs: [],
         namespaces: []
       };
 
@@ -2387,6 +2408,7 @@ describe('ObjCRenderer', function() {
           nullability: ObjC.ClassNullability.default
         }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -2445,6 +2467,7 @@ describe('ObjCRenderer', function() {
           nullability: ObjC.ClassNullability.default
         }
         ],
+        structs: [],
         namespaces: []
       };
 
@@ -2466,6 +2489,7 @@ describe('ObjCRenderer', function() {
         functions: [],
         diagnosticIgnores:[],
         classes: [],
+        structs: [],
         namespaces: []
       };
 

--- a/src/__tests__/plugins/algebraic-type-templated-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-templated-matching-test.ts
@@ -106,9 +106,9 @@ describe('Plugins.AlgebraicTypeTemplatedMatching', function() {
         functions: [],
         diagnosticIgnores:[],
         classes: [],
-        namespaces: [
+        structs: [
           {
-            name: 'RMTestMatching',
+            name: 'RMTestMatcher',
             templates: [
               {
                 templatedTypes: [
@@ -117,60 +117,52 @@ describe('Plugins.AlgebraicTypeTemplatedMatching', function() {
                     value: 'T'
                   }
                 ],
-                code: [
-                  'extern T match(RMTest *test, T(^someSubtypeMatchHandler)(NSString *someString, NSUInteger someUnsignedInteger), T(^greatThingMatchHandler)(), T(^coolSingleAttributeSubtypeMatchHandler)(SingleAttributeType *coolSingleAttributeSubtype)) {',
-                  '  NSCAssert(test != nil, @"The ADT object test is nil");',
-                  '  __block std::shared_ptr<T> result;',
-                  '',
-                  '  RMTestSomeSubtypeMatchHandler matchSomeSubtype = ^(NSString *someString, NSUInteger someUnsignedInteger) {',
-                  '    result = std::make_shared<T>(someSubtypeMatchHandler(someString, someUnsignedInteger));',
-                  '  };',
-                  '',
-                  '  RMTestGreatThingMatchHandler matchGreatThing = ^() {',
-                  '    result = std::make_shared<T>(greatThingMatchHandler());',
-                  '  };',
-                  '',
-                  '  RMTestCoolSingleAttributeSubtypeMatchHandler matchCoolSingleAttributeSubtype = ^(SingleAttributeType *coolSingleAttributeSubtype) {',
-                  '    result = std::make_shared<T>(coolSingleAttributeSubtypeMatchHandler(coolSingleAttributeSubtype));',
-                  '  };',
-                  '',
-                  '  [test matchSomeSubtype:matchSomeSubtype greatThing:matchGreatThing coolSingleAttributeSubtype:matchCoolSingleAttributeSubtype];',
-                  '  return *result;',
-                  '}'
-                ]
-              },
-              {
-                templatedTypes: [
-                  {
-                    type: CPlusPlus.TemplateType.Typename(),
-                    value: 'T'
-                  }
-                ],
-                code: [
-                  'extern T match(T(^someSubtypeMatchHandler)(NSString *someString, NSUInteger someUnsignedInteger), T(^greatThingMatchHandler)(), T(^coolSingleAttributeSubtypeMatchHandler)(SingleAttributeType *coolSingleAttributeSubtype), RMTest *test) {',
-                  '  NSCAssert(test != nil, @"The ADT object test is nil");',
-                  '  __block std::shared_ptr<T> result;',
-                  '',
-                  '  RMTestSomeSubtypeMatchHandler matchSomeSubtype = ^(NSString *someString, NSUInteger someUnsignedInteger) {',
-                  '    result = std::make_shared<T>(someSubtypeMatchHandler(someString, someUnsignedInteger));',
-                  '  };',
-                  '',
-                  '  RMTestGreatThingMatchHandler matchGreatThing = ^() {',
-                  '    result = std::make_shared<T>(greatThingMatchHandler());',
-                  '  };',
-                  '',
-                  '  RMTestCoolSingleAttributeSubtypeMatchHandler matchCoolSingleAttributeSubtype = ^(SingleAttributeType *coolSingleAttributeSubtype) {',
-                  '    result = std::make_shared<T>(coolSingleAttributeSubtypeMatchHandler(coolSingleAttributeSubtype));',
-                  '  };',
-                  '',
-                  '  [test matchSomeSubtype:matchSomeSubtype greatThing:matchGreatThing coolSingleAttributeSubtype:matchCoolSingleAttributeSubtype];',
-                  '  return *result;',
-                  '}'
-                ]
+                code: []
               }
+            ],
+            code: [
+              ['static T match(RMTest *test, T(^someSubtypeMatchHandler)(NSString *someString, NSUInteger someUnsignedInteger), T(^greatThingMatchHandler)(), T(^coolSingleAttributeSubtypeMatchHandler)(SingleAttributeType *coolSingleAttributeSubtype)) {',
+              '  NSCAssert(test != nil, @"The ADT object test is nil");',
+              '  __block std::shared_ptr<T> result;',
+              '',
+              '  RMTestSomeSubtypeMatchHandler matchSomeSubtype = ^(NSString *someString, NSUInteger someUnsignedInteger) {',
+              '    result = std::make_shared<T>(someSubtypeMatchHandler(someString, someUnsignedInteger));',
+              '  };',
+              '',
+              '  RMTestGreatThingMatchHandler matchGreatThing = ^() {',
+              '    result = std::make_shared<T>(greatThingMatchHandler());',
+              '  };',
+              '',
+              '  RMTestCoolSingleAttributeSubtypeMatchHandler matchCoolSingleAttributeSubtype = ^(SingleAttributeType *coolSingleAttributeSubtype) {',
+              '    result = std::make_shared<T>(coolSingleAttributeSubtypeMatchHandler(coolSingleAttributeSubtype));',
+              '  };',
+              '',
+              '  [test matchSomeSubtype:matchSomeSubtype greatThing:matchGreatThing coolSingleAttributeSubtype:matchCoolSingleAttributeSubtype];',
+              '  return *result;',
+              '}'],
+              ['static T match(T(^someSubtypeMatchHandler)(NSString *someString, NSUInteger someUnsignedInteger), T(^greatThingMatchHandler)(), T(^coolSingleAttributeSubtypeMatchHandler)(SingleAttributeType *coolSingleAttributeSubtype), RMTest *test) {',
+              '  NSCAssert(test != nil, @"The ADT object test is nil");',
+              '  __block std::shared_ptr<T> result;',
+              '',
+              '  RMTestSomeSubtypeMatchHandler matchSomeSubtype = ^(NSString *someString, NSUInteger someUnsignedInteger) {',
+              '    result = std::make_shared<T>(someSubtypeMatchHandler(someString, someUnsignedInteger));',
+              '  };',
+              '',
+              '  RMTestGreatThingMatchHandler matchGreatThing = ^() {',
+              '    result = std::make_shared<T>(greatThingMatchHandler());',
+              '  };',
+              '',
+              '  RMTestCoolSingleAttributeSubtypeMatchHandler matchCoolSingleAttributeSubtype = ^(SingleAttributeType *coolSingleAttributeSubtype) {',
+              '    result = std::make_shared<T>(coolSingleAttributeSubtypeMatchHandler(coolSingleAttributeSubtype));',
+              '  };',
+              '',
+              '  [test matchSomeSubtype:matchSomeSubtype greatThing:matchGreatThing coolSingleAttributeSubtype:matchCoolSingleAttributeSubtype];',
+              '  return *result;',
+              '}']
             ]
           }
-        ]
+        ],
+        namespaces: []
       };
 
       expect(additionalFiles).toContain(expectedFile);

--- a/src/__tests__/plugins/builder-test.ts
+++ b/src/__tests__/plugins/builder-test.ts
@@ -140,6 +140,7 @@ describe('Plugins.Builder', function() {
               nullability: ObjC.ClassNullability.default
             }
           ],
+          structs: [],
           namespaces: []
         }
       ];
@@ -266,6 +267,7 @@ describe('Plugins.Builder', function() {
               nullability: ObjC.ClassNullability.default
             }
           ],
+          structs: [],
           namespaces: []
         }
       ];
@@ -547,6 +549,7 @@ describe('Plugins.Builder', function() {
               nullability: ObjC.ClassNullability.default
             }
           ],
+          structs: [],
           namespaces: []
         }
       ];

--- a/src/__tests__/value-object-creation-test.ts
+++ b/src/__tests__/value-object-creation-test.ts
@@ -195,6 +195,7 @@ describe('ValueObjectCreation', function() {
                   nullability: ObjC.ClassNullability.default
                 }
               ],
+              structs: [],
               namespaces: []
             }
           ];

--- a/src/code.ts
+++ b/src/code.ts
@@ -51,5 +51,6 @@ export interface File {
   functions:ObjC.Function[];
   classes:ObjC.Class[];
   diagnosticIgnores:string[];
+  structs:CPlusPlus.Struct[];
   namespaces:CPlusPlus.Namespace[];
 }

--- a/src/cplusplus.ts
+++ b/src/cplusplus.ts
@@ -46,6 +46,12 @@ export interface Template {
   code:string[];
 }
 
+export interface Struct {
+  name:string;
+  templates:Template[];
+  code:string[][];
+}
+
 export interface Namespace {
   name:string;
   templates:Template[];

--- a/src/objc-renderer.ts
+++ b/src/objc-renderer.ts
@@ -338,6 +338,16 @@ function buildTemplateContents(soFar:string[], templateContents:string[]):string
   return soFar.concat(templateContents);
 }
 
+function toStructContents(struct) {
+    var structDeclaration = 'struct ' + struct.name + ' {' + '\n';
+    var endStructDeclaration = '};';
+    return struct.templates.map(toTemplateContents).reduce(buildTemplateContents, []).concat(structDeclaration).concat(struct.code.reduce(buildStructContents, []).map(StringUtils.indent(2))).concat(endStructDeclaration).join('\n');
+}
+
+function buildStructContents(soFar, structContents) {
+    return soFar.concat(structContents);
+}
+
 function toNamespaceContents(namespace:CPlusPlus.Namespace):string {
   const namespaceDeclaration:string = 'namespace ' + namespace.name + ' {';
   const endNamespaceDeclaration:string = '}';
@@ -436,11 +446,14 @@ export function renderHeader(file:Code.File):Maybe.Maybe<string> {
   const functionsSection = codeSectionForCodeString(headerFunctionsSection(file.functions));
 
   const classSection = file.classes.map(headerClassSection).join('\n\n');
-
+  
+  const structsStr = file.structs.map(toStructContents).join('\n');
+  const structsSection = codeSectionForCodeString(structsStr);
+  
   const namespacesStr:string = file.namespaces.map(toNamespaceContents).join('\n');
   const namespacesSection:string = codeSectionForCodeString(namespacesStr);
 
-  const contents:string = commentsSection + importsSection + declarationsSection + enumerationsSection + blocksSection + functionsSection + namespacesSection + classSection + '\n\n';
+  const contents:string = commentsSection + importsSection + declarationsSection + enumerationsSection + blocksSection + functionsSection + structsSection + namespacesSection + classSection + '\n\n';
   return Maybe.Just<string>(contents);
 }
 

--- a/src/pluggable-objc-file-creation.ts
+++ b/src/pluggable-objc-file-creation.ts
@@ -243,6 +243,7 @@ function classFileCreationFunctionWithBaseClassAndPlugins<T>(baseClassName:strin
           }, nullability)
         }
         ],
+        structs: [],
         namespaces: []
       };
     }, fileType);

--- a/src/plugins/algebraic-type-templated-matching.ts
+++ b/src/plugins/algebraic-type-templated-matching.ts
@@ -83,7 +83,7 @@ function functionParameterProviderWithAlgebraicTypeLast(algebraicType:AlgebraicT
 }
 
 function matcherFunctionCodeForAlgebraicType(algebraicType:AlgebraicType.Type, functionParameterProvider:(algebraicType:AlgebraicType.Type) => string[]):string[] {
-  const functionDeclaration:string = 'extern T match(' + functionParameterProvider(algebraicType).join(', ') + ') {';
+  const functionDeclaration:string = 'static T match(' + functionParameterProvider(algebraicType).join(', ') + ') {';
   const matcherFunctionParameterName:string = matcherFunctionParameterNameForAlgebraicType(algebraicType);
   const assertionCode:string = 'NSCAssert(' + matcherFunctionParameterName + ' != nil, @"The ADT object ' + matcherFunctionParameterName + ' is nil");';
   const resultDeclaration:string = '__block std::shared_ptr<T> result;';
@@ -111,12 +111,15 @@ function templateForMatchingAlgebraicTypeWithCode(code:string[]):CPlusPlus.Templ
   };
 }
 
-function namespaceForMatchingAlgebraicType(algebraicType:AlgebraicType.Type):CPlusPlus.Namespace {
+function structForMatchingAlgebraicType(algebraicType:AlgebraicType.Type):CPlusPlus.Struct {
   return {
-    name: algebraicType.name + 'Matching',
+    name: algebraicType.name + 'Matcher',
     templates: [
-      templateForMatchingAlgebraicTypeWithCode(matcherFunctionCodeForAlgebraicType(algebraicType, functionParameterProviderWithAlgebraicTypeFirst)),
-      templateForMatchingAlgebraicTypeWithCode(matcherFunctionCodeForAlgebraicType(algebraicType, functionParameterProviderWithAlgebraicTypeLast))
+      templateForMatchingAlgebraicTypeWithCode([])
+    ],
+    code: [
+      matcherFunctionCodeForAlgebraicType(algebraicType, functionParameterProviderWithAlgebraicTypeFirst),
+      matcherFunctionCodeForAlgebraicType(algebraicType, functionParameterProviderWithAlgebraicTypeLast)
     ]
   };
 }
@@ -139,7 +142,8 @@ function matchingFileForAlgebraicType(algebraicType:AlgebraicType.Type):Code.Fil
     functions: [],
     classes: [],
     diagnosticIgnores:[],
-    namespaces: [namespaceForMatchingAlgebraicType(algebraicType)]
+    structs: [structForMatchingAlgebraicType(algebraicType)],
+    namespaces: []
   };
 }
 

--- a/src/plugins/builder.ts
+++ b/src/plugins/builder.ts
@@ -288,6 +288,7 @@ function builderFileForValueType(valueType:ValueObject.Type):Code.File {
       }
     ],
     diagnosticIgnores:[],
+    structs: [],
     namespaces: []
   };
 }


### PR DESCRIPTION
Autocompletes are not working well on templated matching, making it very hard to write if using. This diff makes it such that the templated type T is defined at the struct level so that the match function can be correctly autocompleted.

The only issue here is that if a pointer to a class is used as the template class, a __strong qualifier that is automatically added. and a compiler warning is emitted. However that can be safely ignored and should be removed

