### PR TITLE
Provide valueObjectConfig path as argument

### DIFF
--- a/src/__tests__/commandline-test.ts
+++ b/src/__tests__/commandline-test.ts
@@ -32,6 +32,7 @@ describe('CommandLine', function() {
 
       const expectedResult = Maybe.Just<CommandLine.Arguments>({
         givenPath:'project/to/generate',
+        valueObjectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
         minimalLevel:10,
         dryRun: false
@@ -46,6 +47,7 @@ describe('CommandLine', function() {
 
       const expectedResult = Maybe.Just<CommandLine.Arguments>({
         givenPath:'project/to/generate',
+        valueObjectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
         minimalLevel:1,
         dryRun:false
@@ -60,6 +62,7 @@ describe('CommandLine', function() {
 
       const expectedResult = Maybe.Just<CommandLine.Arguments>({
         givenPath:'project/to/generate',
+        valueObjectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error, Logging.LoggingType.performance),
         minimalLevel:10,
         dryRun:false
@@ -74,6 +77,7 @@ describe('CommandLine', function() {
 
       const expectedResult = Maybe.Just<CommandLine.Arguments>({
         givenPath:'project/to/generate',
+        valueObjectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error, Logging.LoggingType.debug),
         minimalLevel:10,
         dryRun:false
@@ -88,6 +92,7 @@ describe('CommandLine', function() {
 
       const expectedResult = Maybe.Just<CommandLine.Arguments>({
         givenPath:'project/to/generate',
+        valueObjectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
         minimalLevel:10,
         dryRun:true
@@ -102,9 +107,25 @@ describe('CommandLine', function() {
 
       const expectedResult = Maybe.Just<CommandLine.Arguments>({
         givenPath:'project/to/generate',
+        valueObjectConfigPath:undefined,
         interestedLoggingTypes:List.of<Logging.LoggingType>(),
         minimalLevel:10,
         dryRun:false
+      });
+
+      expect(parsedArgs).toEqualJSON(expectedResult);
+    });
+
+    it('includes valueObjectConfigPath', function() {
+      const args:string[] = ['project/to/generate', 'path/to/valueObject/Config'];
+      const parsedArgs:Maybe.Maybe<CommandLine.Arguments> = CommandLine.parseArgs(args);
+
+      const expectedResult = Maybe.Just<CommandLine.Arguments>({
+        givenPath:'project/to/generate',
+        valueObjectConfigPath:'path/to/valueObject/Config',
+        interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
+        minimalLevel:10,
+        dryRun: false
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);

--- a/src/commandline.ts
+++ b/src/commandline.ts
@@ -16,6 +16,7 @@ import minimist = require('minimist');
 
 export interface Arguments {
   givenPath:string;
+  valueObjectConfigPath:string;
   interestedLoggingTypes:List.List<Logging.LoggingType>;
   minimalLevel:number;
   dryRun:boolean;
@@ -47,6 +48,7 @@ export function parseArgs(args:string[]):Maybe.Maybe<Arguments> {
   } else {
     return Maybe.Just({
       givenPath:parsedArgs._[0],
+      valueObjectConfigPath:parsedArgs._[1],
       interestedLoggingTypes:interestedTypesForArgs(parsedArgs),
       minimalLevel:parsedArgs[VERBOSE_FLAG] ? 1 : 10,
       dryRun:parsedArgs[DRY_RUN_FLAG]

--- a/src/value-objects.ts
+++ b/src/value-objects.ts
@@ -144,17 +144,20 @@ function getValueObjectCreationContext(valueObjectConfigPathFuture:Promise.Futur
   }, valueObjectConfigPathFuture);
 }
 
+function valueObjectConfigPathFuture(requestedPath:File.AbsoluteFilePath, configPathFromArguments:string): Promise.Future<Maybe.Maybe<File.AbsoluteFilePath>> {
+  var absoluteValueObjectConfigPath: Promise.Future<Maybe.Maybe<File.AbsoluteFilePath>>;
+  if (configPathFromArguments === undefined) {
+      absoluteValueObjectConfigPath = FileFinder.findConfig('.valueObjectConfig', requestedPath);
+  } else {
+      absoluteValueObjectConfigPath = Promise.munit(Maybe.Just(File.getAbsoluteFilePath(configPathFromArguments)));
+  }
+  return absoluteValueObjectConfigPath;
+}
+
 export function generate(directoryRunFrom:string, parsedArgs:CommandLine.Arguments):Promise.Future<WriteFileUtils.ConsoleOutputResults> {
     const requestedPath:File.AbsoluteFilePath = PathUtils.getAbsolutePathFromDirectoryAndAbsoluteOrRelativePath(File.getAbsoluteFilePath(directoryRunFrom), parsedArgs.givenPath);
 
-    var absoluteValueObjectConfigPath: Promise.Future<Maybe.Maybe<File.AbsoluteFilePath>>;
-    if (parsedArgs.valueObjectConfigPath === undefined) {
-        absoluteValueObjectConfigPath = FileFinder.findConfig('.valueObjectConfig', requestedPath);
-    } else {
-        absoluteValueObjectConfigPath = Promise.munit(Maybe.Just(File.getAbsoluteFilePath(parsedArgs.valueObjectConfigPath)));
-    }
-
-    const valueObjectCreationContextFuture = getValueObjectCreationContext(absoluteValueObjectConfigPath);
+    const valueObjectCreationContextFuture = getValueObjectCreationContext(valueObjectConfigPathFuture(requestedPath, parsedArgs.valueObjectConfigPath));
 
     const readFileSequence = ReadFileUtils.loggedSequenceThatReadsFiles(requestedPath, 'value');
 

--- a/src/value-objects.ts
+++ b/src/value-objects.ts
@@ -120,8 +120,7 @@ function pluginsFromPluginConfigs(pluginConfigs:List.List<Configuration.PluginCo
   }, Either.Right<Error.Error[], List.List<ValueObject.Plugin>>(List.of<ValueObject.Plugin>()), pluginConfigs);
 }
 
-function getValueObjectCreationContext(currentWorkingDirectory:File.AbsoluteFilePath):Promise.Future<Either.Either<Error.Error[], ValueObjectCreationContext>> {
-  const findConfigFuture = FileFinder.findConfig('.valueObjectConfig', currentWorkingDirectory);
+function getValueObjectCreationContext(valueObjectConfigPathFuture:Promise.Future<Maybe.Maybe<File.AbsoluteFilePath>>):Promise.Future<Either.Either<Error.Error[], ValueObjectCreationContext>> {
   return Promise.mbind(function(maybePath:Maybe.Maybe<File.AbsoluteFilePath>):Promise.Future<Either.Either<Error.Error[], ValueObjectCreationContext>> {
     const configurationContext:Configuration.ConfigurationContext = {
       basePlugins: BASE_PLUGINS,
@@ -142,13 +141,20 @@ function getValueObjectCreationContext(currentWorkingDirectory:File.AbsoluteFile
         }, pluginsEither);
       }, either);
     }, configFuture);
-  }, findConfigFuture);
+  }, valueObjectConfigPathFuture);
 }
 
 export function generate(directoryRunFrom:string, parsedArgs:CommandLine.Arguments):Promise.Future<WriteFileUtils.ConsoleOutputResults> {
     const requestedPath:File.AbsoluteFilePath = PathUtils.getAbsolutePathFromDirectoryAndAbsoluteOrRelativePath(File.getAbsoluteFilePath(directoryRunFrom), parsedArgs.givenPath);
 
-    const valueObjectCreationContextFuture = getValueObjectCreationContext(requestedPath);
+    var absoluteValueObjectConfigPath: Promise.Future<Maybe.Maybe<File.AbsoluteFilePath>>;
+    if (parsedArgs.valueObjectConfigPath === undefined) {
+        absoluteValueObjectConfigPath = FileFinder.findConfig('.valueObjectConfig', requestedPath);
+    } else {
+        absoluteValueObjectConfigPath = Promise.munit(Maybe.Just(File.getAbsoluteFilePath(parsedArgs.valueObjectConfigPath)));
+    }
+
+    const valueObjectCreationContextFuture = getValueObjectCreationContext(absoluteValueObjectConfigPath);
 
     const readFileSequence = ReadFileUtils.loggedSequenceThatReadsFiles(requestedPath, 'value');
 


### PR DESCRIPTION
This diff introduces ability to provide .valueObjectConfig absolute path as an argument to remodel binary. Similar work should be done for .adtValue but I wanted to pilot it first on value objects themselves.