### PR TITLE
Add support for protocol forward declaration

### DIFF
--- a/features/forward-declaration.feature
+++ b/features/forward-declaration.feature
@@ -229,3 +229,26 @@ Feature: Outputting Value Objects With Forward Declarations
       #pragma clang diagnostic pop
 
       """
+  @announce
+  Scenario: Generating Files with SkipAttributePrivateImports results in no additional imports
+    Given a file named "project/values/RMPage.value" with:
+      """
+      RMPage includes(UseForwardDeclarations, SkipAttributePrivateImports) {
+        UIViewController<WorldProtocol> *worldVc
+        RMProxy* proxy
+        HelloClass *helloObj
+        NSArray<RMSomeType *>* followers
+      }
+      """
+    And a file named "project/.valueObjectConfig" with:
+      """
+      { }
+      """
+    When I run `../../bin/generate project`
+    Then the file "project/values/RMPage.m" should contain:
+      """
+      #import "RMPage.h"
+
+      @implementation RMPage
+
+      """

--- a/features/forward-declaration.feature
+++ b/features/forward-declaration.feature
@@ -6,6 +6,7 @@ Feature: Outputting Value Objects With Forward Declarations
       """
       # Important and gripping comment
       # that takes up two lines.
+      %type name=RMSomeType library=FooLibrary
       RMPage includes(UseForwardDeclarations) {
         BOOL doesUserLike
         NSString* identifier
@@ -14,6 +15,7 @@ Feature: Outputting Value Objects With Forward Declarations
         NSInteger likeCount
         NSUInteger numberOfRatings
         RMProxy* proxy
+        NSArray<RMSomeType *>* followers
       }
       """
     And a file named "project/.valueObjectConfig" with:
@@ -25,6 +27,7 @@ Feature: Outputting Value Objects With Forward Declarations
       """
       #import <Foundation/Foundation.h>
 
+      @class RMSomeType;
       @class RMProxy;
 
       /**
@@ -42,8 +45,9 @@ Feature: Outputting Value Objects With Forward Declarations
       @property (nonatomic, readonly) NSInteger likeCount;
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
       @property (nonatomic, readonly, copy) RMProxy *proxy;
+      @property (nonatomic, readonly, copy) NSArray<RMSomeType *> *followers;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy followers:(NSArray<RMSomeType *> *)followers;
 
       @end
 
@@ -51,11 +55,12 @@ Feature: Outputting Value Objects With Forward Declarations
    And the file "project/values/RMPage.m" should contain:
       """
       #import "RMPage.h"
+      #import <FooLibrary/RMSomeType.h>
       #import "RMProxy.h"
 
       @implementation RMPage
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy followers:(NSArray<RMSomeType *> *)followers
       {
         if ((self = [super init])) {
           _doesUserLike = doesUserLike;
@@ -63,6 +68,7 @@ Feature: Outputting Value Objects With Forward Declarations
           _likeCount = likeCount;
           _numberOfRatings = numberOfRatings;
           _proxy = [proxy copy];
+          _followers = [followers copy];
         }
 
         return self;
@@ -75,14 +81,14 @@ Feature: Outputting Value Objects With Forward Declarations
 
       - (NSString *)description
       {
-        return [NSString stringWithFormat:@"%@ - \n\t doesUserLike: %@; \n\t identifier: %@; \n\t likeCount: %zd; \n\t numberOfRatings: %tu; \n\t proxy: %@; \n", [super description], _doesUserLike ? @"YES" : @"NO", _identifier, _likeCount, _numberOfRatings, _proxy];
+        return [NSString stringWithFormat:@"%@ - \n\t doesUserLike: %@; \n\t identifier: %@; \n\t likeCount: %zd; \n\t numberOfRatings: %tu; \n\t proxy: %@; \n\t followers: %@; \n", [super description], _doesUserLike ? @"YES" : @"NO", _identifier, _likeCount, _numberOfRatings, _proxy, _followers];
       }
 
       - (NSUInteger)hash
       {
-        NSUInteger subhashes[] = {(NSUInteger)_doesUserLike, [_identifier hash], ABS(_likeCount), _numberOfRatings, [_proxy hash]};
+        NSUInteger subhashes[] = {(NSUInteger)_doesUserLike, [_identifier hash], ABS(_likeCount), _numberOfRatings, [_proxy hash], [_followers hash]};
         NSUInteger result = subhashes[0];
-        for (int ii = 1; ii < 5; ++ii) {
+        for (int ii = 1; ii < 6; ++ii) {
           unsigned long long base = (((unsigned long long)result) << 32 | subhashes[ii]);
           base = (~base) + (base << 18);
           base ^= (base >> 31);
@@ -107,7 +113,8 @@ Feature: Outputting Value Objects With Forward Declarations
           _likeCount == object->_likeCount &&
           _numberOfRatings == object->_numberOfRatings &&
           (_identifier == object->_identifier ? YES : [_identifier isEqual:object->_identifier]) &&
-          (_proxy == object->_proxy ? YES : [_proxy isEqual:object->_proxy]);
+          (_proxy == object->_proxy ? YES : [_proxy isEqual:object->_proxy]) &&
+          (_followers == object->_followers ? YES : [_followers isEqual:object->_followers]);
       }
 
       @end

--- a/features/forward-declaration.feature
+++ b/features/forward-declaration.feature
@@ -7,6 +7,7 @@ Feature: Outputting Value Objects With Forward Declarations
       # Important and gripping comment
       # that takes up two lines.
       %type name=RMSomeType library=FooLibrary
+      %type name=UIViewController library=UIKit
       RMPage includes(UseForwardDeclarations) {
         BOOL doesUserLike
         NSString* identifier
@@ -16,6 +17,10 @@ Feature: Outputting Value Objects With Forward Declarations
         NSUInteger numberOfRatings
         RMProxy* proxy
         NSArray<RMSomeType *>* followers
+        %import library=HelloKit file=HelloProtocol
+        id<HelloProtocol> helloObj
+        %import library=WorldKit file=HWorldProtocol
+        UIViewController<WorldProtocol> *worldVc
       }
       """
     And a file named "project/.valueObjectConfig" with:
@@ -28,7 +33,10 @@ Feature: Outputting Value Objects With Forward Declarations
       #import <Foundation/Foundation.h>
 
       @class RMSomeType;
+      @class UIViewController;
       @class RMProxy;
+      @protocol HelloProtocol;
+      @protocol WorldProtocol;
 
       /**
        * Important and gripping comment
@@ -46,8 +54,10 @@ Feature: Outputting Value Objects With Forward Declarations
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
       @property (nonatomic, readonly, copy) RMProxy *proxy;
       @property (nonatomic, readonly, copy) NSArray<RMSomeType *> *followers;
+      @property (nonatomic, readonly, copy) id<HelloProtocol> helloObj;
+      @property (nonatomic, readonly, copy) UIViewController<WorldProtocol> *worldVc;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy followers:(NSArray<RMSomeType *> *)followers;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy followers:(NSArray<RMSomeType *> *)followers helloObj:(id<HelloProtocol>)helloObj worldVc:(UIViewController<WorldProtocol> *)worldVc;
 
       @end
 
@@ -56,11 +66,14 @@ Feature: Outputting Value Objects With Forward Declarations
       """
       #import "RMPage.h"
       #import <FooLibrary/RMSomeType.h>
+      #import <UIKit/UIViewController.h>
       #import "RMProxy.h"
+      #import <HelloKit/HelloProtocol.h>
+      #import <WorldKit/HWorldProtocol.h>
 
       @implementation RMPage
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy followers:(NSArray<RMSomeType *> *)followers
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy followers:(NSArray<RMSomeType *> *)followers helloObj:(id<HelloProtocol>)helloObj worldVc:(UIViewController<WorldProtocol> *)worldVc
       {
         if ((self = [super init])) {
           _doesUserLike = doesUserLike;
@@ -69,6 +82,8 @@ Feature: Outputting Value Objects With Forward Declarations
           _numberOfRatings = numberOfRatings;
           _proxy = [proxy copy];
           _followers = [followers copy];
+          _helloObj = [helloObj copy];
+          _worldVc = [worldVc copy];
         }
 
         return self;
@@ -81,14 +96,14 @@ Feature: Outputting Value Objects With Forward Declarations
 
       - (NSString *)description
       {
-        return [NSString stringWithFormat:@"%@ - \n\t doesUserLike: %@; \n\t identifier: %@; \n\t likeCount: %zd; \n\t numberOfRatings: %tu; \n\t proxy: %@; \n\t followers: %@; \n", [super description], _doesUserLike ? @"YES" : @"NO", _identifier, _likeCount, _numberOfRatings, _proxy, _followers];
+        return [NSString stringWithFormat:@"%@ - \n\t doesUserLike: %@; \n\t identifier: %@; \n\t likeCount: %zd; \n\t numberOfRatings: %tu; \n\t proxy: %@; \n\t followers: %@; \n\t helloObj: %@; \n\t worldVc: %@; \n", [super description], _doesUserLike ? @"YES" : @"NO", _identifier, _likeCount, _numberOfRatings, _proxy, _followers, _helloObj, _worldVc];
       }
 
       - (NSUInteger)hash
       {
-        NSUInteger subhashes[] = {(NSUInteger)_doesUserLike, [_identifier hash], ABS(_likeCount), _numberOfRatings, [_proxy hash], [_followers hash]};
+        NSUInteger subhashes[] = {(NSUInteger)_doesUserLike, [_identifier hash], ABS(_likeCount), _numberOfRatings, [_proxy hash], [_followers hash], [_helloObj hash], [_worldVc hash]};
         NSUInteger result = subhashes[0];
-        for (int ii = 1; ii < 6; ++ii) {
+        for (int ii = 1; ii < 8; ++ii) {
           unsigned long long base = (((unsigned long long)result) << 32 | subhashes[ii]);
           base = (~base) + (base << 18);
           base ^= (base >> 31);
@@ -114,7 +129,9 @@ Feature: Outputting Value Objects With Forward Declarations
           _numberOfRatings == object->_numberOfRatings &&
           (_identifier == object->_identifier ? YES : [_identifier isEqual:object->_identifier]) &&
           (_proxy == object->_proxy ? YES : [_proxy isEqual:object->_proxy]) &&
-          (_followers == object->_followers ? YES : [_followers isEqual:object->_followers]);
+          (_followers == object->_followers ? YES : [_followers isEqual:object->_followers]) &&
+          (_helloObj == object->_helloObj ? YES : [_helloObj isEqual:object->_helloObj]) &&
+          (_worldVc == object->_worldVc ? YES : [_worldVc isEqual:object->_worldVc]);
       }
 
       @end

--- a/src/__tests__/algebraic-type-parser-test.ts
+++ b/src/__tests__/algebraic-type-parser-test.ts
@@ -43,6 +43,7 @@ describe('AlgebraicTypeParser', function() {
                 fileTypeIsDefinedIn:Maybe.Nothing<string>(),
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol:Maybe.Nothing<string>(),
                 reference: 'uint64_t',
                 name: 'uint64_t'
                 },
@@ -77,6 +78,7 @@ describe('AlgebraicTypeParser', function() {
                 fileTypeIsDefinedIn:Maybe.Nothing<string>(),
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 underlyingType:Maybe.Just('NSObject'),
+                conformingProtocol:Maybe.Nothing<string>(),
                 reference: 'RMObject*',
                 name: 'RMObject'
                 },
@@ -139,6 +141,7 @@ describe('AlgebraicTypeParser', function() {
                 fileTypeIsDefinedIn:Maybe.Just('RMSomeOtherFile'),
                 libraryTypeIsDefinedIn:Maybe.Just('RMCustomLibrary'),
                 underlyingType:Maybe.Just('NSObject'),
+                conformingProtocol:Maybe.Nothing<string>(),
                 reference: 'RMObject*',
                 name: 'RMObject'
                 },
@@ -202,7 +205,8 @@ describe('AlgebraicTypeParser', function() {
                   libraryTypeIsDefinedIn:Maybe.Just('RMCustomLibrary'),
                   name:'RMBlah',
                   reference: 'RMBlah*',
-                  underlyingType:Maybe.Just<string>('NSObject')
+                  underlyingType:Maybe.Just<string>('NSObject'),
+                  conformingProtocol:Maybe.Nothing<string>()
                 }
               },
               {
@@ -215,7 +219,8 @@ describe('AlgebraicTypeParser', function() {
                   libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                   name:'RMSomeValue',
                   reference: 'RMSomeValue',
-                  underlyingType:Maybe.Just('BOOL')
+                  underlyingType:Maybe.Just('BOOL'),
+                  conformingProtocol:Maybe.Nothing<string>()
                 }
               },
             ]
@@ -264,7 +269,8 @@ describe('AlgebraicTypeParser', function() {
                   libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                   name:'RMBlah',
                   reference: 'RMBlah*',
-                  underlyingType:Maybe.Just<string>('NSObject')
+                  underlyingType:Maybe.Just<string>('NSObject'),
+                  conformingProtocol:Maybe.Nothing<string>()
                 }
               },
               {
@@ -283,7 +289,8 @@ describe('AlgebraicTypeParser', function() {
                   libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                   name:'RMBlah',
                   reference: 'RMBlah*',
-                  underlyingType:Maybe.Just<string>('NSObject')
+                  underlyingType:Maybe.Just<string>('NSObject'),
+                  conformingProtocol:Maybe.Nothing<string>()
                 }
               },
             ]

--- a/src/__tests__/plugins/algebraic-type-function-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-function-matching-test.ts
@@ -45,7 +45,8 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
                   reference: 'NSString *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -58,7 +59,8 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
                   reference: 'NSUInteger',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -74,7 +76,8 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
               reference: 'SingleAttributeType *',
               libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject')
+              underlyingType: Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -157,7 +160,8 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
                   reference: 'NSString *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -170,7 +174,8 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
                   reference: 'NSUInteger',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -186,7 +191,8 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
               reference: 'SingleAttributeType *',
               libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject')
+              underlyingType: Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]

--- a/src/__tests__/plugins/algebraic-type-initialization-test.ts
+++ b/src/__tests__/plugins/algebraic-type-initialization-test.ts
@@ -138,7 +138,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                   reference: 'Foo *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -151,7 +152,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                   reference: 'BOOL',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -167,7 +169,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
               reference: 'SingleAttributeType *',
               libraryTypeIsDefinedIn: Maybe.Just('SomeLib'),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject')
+              underlyingType: Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -221,7 +224,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
               reference: 'Foo *',
               libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject')
+              underlyingType: Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -309,7 +313,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                   reference: 'NSString *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -322,7 +327,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                   reference: 'NSUInteger',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -338,7 +344,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
               reference: 'SingleAttributeType *',
               libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject')
+              underlyingType: Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -444,7 +451,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                   reference: 'NSString *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -457,7 +465,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                   reference: 'NSUInteger',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -473,7 +482,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
               reference: 'SingleAttributeType *',
               libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject')
+              underlyingType: Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -552,7 +562,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                   reference: 'NSString *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -565,7 +576,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                   reference: 'NSUInteger',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -581,7 +593,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
               reference: 'SingleAttributeType *',
               libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject')
+              underlyingType: Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -655,7 +668,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                   reference: 'Foo *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -675,7 +689,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                   reference: 'Foo *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -710,7 +725,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             reference: 'SingleAttributeType *',
             libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
             fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-            underlyingType: Maybe.Just<string>('NSObject')
+            underlyingType: Maybe.Just<string>('NSObject'),
+            conformingProtocol: Maybe.Nothing<string>()
           }
         }),
         AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
@@ -724,7 +740,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             reference: 'SingleAttributeType *',
             libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
             fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-            underlyingType: Maybe.Just<string>('NSObject')
+            underlyingType: Maybe.Just<string>('NSObject'),
+            conformingProtocol: Maybe.Nothing<string>()
           }
         })
         ]
@@ -761,7 +778,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                 reference: 'Foo *',
                 libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                 fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                underlyingType: Maybe.Nothing<string>()
+                underlyingType: Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ]
@@ -777,7 +795,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             reference: 'NSString *',
             libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
             fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-            underlyingType: Maybe.Nothing<string>()
+            underlyingType: Maybe.Nothing<string>(),
+            conformingProtocol: Maybe.Nothing<string>()
           }
         })
         ]
@@ -817,7 +836,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                 reference: 'Test *',
                 libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                 fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                underlyingType: Maybe.Nothing<string>()
+                underlyingType: Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ]
@@ -864,7 +884,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                 reference: 'Foo *',
                 libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                 fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                underlyingType: Maybe.Nothing<string>()
+                underlyingType: Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ]
@@ -904,7 +925,8 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
                 reference: 'AnotherTest *',
                 libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                 fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                underlyingType: Maybe.Nothing<string>()
+                underlyingType: Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ]

--- a/src/__tests__/plugins/algebraic-type-templated-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-templated-matching-test.ts
@@ -46,7 +46,8 @@ describe('Plugins.AlgebraicTypeTemplatedMatching', function() {
                   reference: 'NSString *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -59,7 +60,8 @@ describe('Plugins.AlgebraicTypeTemplatedMatching', function() {
                   reference: 'NSUInteger',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -81,7 +83,8 @@ describe('Plugins.AlgebraicTypeTemplatedMatching', function() {
               reference: 'SingleAttributeType *',
               libraryTypeIsDefinedIn: Maybe.Just('SomeLib'),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject')
+              underlyingType: Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]

--- a/src/__tests__/plugins/builder-test.ts
+++ b/src/__tests__/plugins/builder-test.ts
@@ -290,7 +290,8 @@ describe('Plugins.Builder', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSUInteger',
               reference: 'NSUInteger',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -303,7 +304,8 @@ describe('Plugins.Builder', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'RMCustomObject',
               reference: 'RMCustomObject *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -316,7 +318,8 @@ describe('Plugins.Builder', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'BOOL',
               reference: 'BOOL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -572,7 +575,8 @@ describe('Plugins.Builder', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSUInteger',
               reference: 'NSUInteger',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -585,7 +589,8 @@ describe('Plugins.Builder', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'RMCustomObject',
               reference: 'RMCustomObject *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -598,7 +603,8 @@ describe('Plugins.Builder', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'BOOL',
               reference: 'BOOL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],

--- a/src/__tests__/plugins/coding-test.ts
+++ b/src/__tests__/plugins/coding-test.ts
@@ -51,7 +51,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -64,7 +65,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'LikeStatus',
               reference: 'LikeStatus',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -96,7 +98,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'Name',
               reference: 'Name',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -109,7 +112,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'LikeStatus',
               reference: 'LikeStatus',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -142,7 +146,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'FooBar',
               reference: 'FooBar',
-              underlyingType:Maybe.Just<string>('Baz')
+              underlyingType:Maybe.Just<string>('Baz'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -191,7 +196,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -204,7 +210,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'BOOL',
               reference: 'BOOL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -217,7 +224,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'id',
               reference: 'id',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -305,7 +313,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'CGSize',
               reference: 'CGSize',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -358,7 +367,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -402,7 +412,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -446,7 +457,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -459,7 +471,8 @@ describe('ObjectSpecPlugins.Coding', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSUInteger',
               reference: 'NSUInteger',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -707,7 +720,8 @@ describe('AlgebraicTypePlugins.Coding', function() {
                   reference: 'NSString *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -720,7 +734,8 @@ describe('AlgebraicTypePlugins.Coding', function() {
                   reference: 'NSUInteger',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -736,7 +751,8 @@ describe('AlgebraicTypePlugins.Coding', function() {
               reference: 'SingleAttributeType *',
               libraryTypeIsDefinedIn: Maybe.Just('SomeLib'),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject')
+              underlyingType: Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -850,7 +866,8 @@ describe('AlgebraicTypePlugins.Coding', function() {
                   reference: 'NSString *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -863,7 +880,8 @@ describe('AlgebraicTypePlugins.Coding', function() {
                   reference: 'NSUInteger',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -879,7 +897,8 @@ describe('AlgebraicTypePlugins.Coding', function() {
               reference: 'SingleAttributeType *',
               libraryTypeIsDefinedIn: Maybe.Just('SomeLib'),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject')
+              underlyingType: Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -987,7 +1006,8 @@ describe('AlgebraicTypePlugins.Coding', function() {
                   reference: 'Foo *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -1026,7 +1046,8 @@ describe('AlgebraicTypePlugins.Coding', function() {
                   reference: 'Foo *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -1045,7 +1066,8 @@ describe('AlgebraicTypePlugins.Coding', function() {
                   reference: 'Ferr',
                   libraryTypeIsDefinedIn: Maybe.Just<string>('SomeLib'),
                   fileTypeIsDefinedIn: Maybe.Just<string>('SomethingElse'),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -1085,7 +1107,8 @@ describe('AlgebraicTypePlugins.Coding', function() {
                   reference: 'Ferr',
                   libraryTypeIsDefinedIn: Maybe.Just<string>('SomeLib'),
                   fileTypeIsDefinedIn: Maybe.Just<string>('SomethingElse'),
-                  underlyingType: Maybe.Just<string>('SomethingRandom')
+                  underlyingType: Maybe.Just<string>('SomethingRandom'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]

--- a/src/__tests__/plugins/description-test.ts
+++ b/src/__tests__/plugins/description-test.ts
@@ -52,7 +52,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'NSString',
                 reference: 'NSString *',
-                underlyingType:Maybe.Just<string>('NSObject')
+                underlyingType:Maybe.Just<string>('NSObject'),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             },
             {
@@ -65,7 +66,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'LikeStatus',
                 reference: 'LikeStatus',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -97,7 +99,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'Name',
                 reference: 'Name',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             },
             {
@@ -110,7 +113,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'LikeStatus',
                 reference: 'LikeStatus',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -143,7 +147,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'FooBar',
                 reference: 'FooBar',
-                underlyingType:Maybe.Just<string>('Baz')
+                underlyingType:Maybe.Just<string>('Baz'),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -177,7 +182,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'CGRect',
                 reference: 'CGRect',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -228,7 +234,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'BOOL',
                 reference: 'BOOL',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -279,7 +286,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'NSString',
                 reference: 'NSString *',
-                underlyingType:Maybe.Just<string>('NSObject')
+                underlyingType:Maybe.Just<string>('NSObject'),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -330,7 +338,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'id',
                 reference: 'id',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -381,7 +390,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'NSInteger',
                 reference: 'NSInteger',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -432,7 +442,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'NSUInteger',
                 reference: 'NSUInteger',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -483,7 +494,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'double',
                 reference: 'double',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -534,7 +546,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'float',
                 reference: 'float',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -585,7 +598,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'CGFloat',
                 reference: 'CGFloat',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -636,7 +650,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'NSTimeInterval',
                 reference: 'NSTimeInterval',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -687,7 +702,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'uintptr_t',
                 reference: 'uintptr_t',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -738,7 +754,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'uint64_t',
                 reference: 'uint64_t',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -789,7 +806,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'int32_t',
                 reference: 'int32_t',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -840,7 +858,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'int64_t',
                 reference: 'int64_t',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -892,7 +911,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'SomeEnum',
                 reference: 'SomeEnum',
-                underlyingType:Maybe.Just('NSUInteger')
+                underlyingType:Maybe.Just('NSUInteger'),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -943,7 +963,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'SEL',
                 reference: 'SEL',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -994,7 +1015,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'NSRange',
                 reference: 'NSRange',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -1045,7 +1067,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'CGRect',
                 reference: 'CGRect',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -1096,7 +1119,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'CGPoint',
                 reference: 'CGPoint',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -1147,7 +1171,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'CGSize',
                 reference: 'CGSize',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -1198,7 +1223,8 @@ describe('ObjectSpecPlugins.Description', function() {
                 libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
                 name: 'UIEdgeInsets',
                 reference: 'UIEdgeInsets',
-                underlyingType:Maybe.Nothing<string>()
+                underlyingType:Maybe.Nothing<string>(),
+                conformingProtocol: Maybe.Nothing<string>()
               }
             }
           ],
@@ -1263,7 +1289,8 @@ describe('AlgebraicTypePlugins.Description', function() {
                   reference: 'NSString *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -1276,7 +1303,8 @@ describe('AlgebraicTypePlugins.Description', function() {
                   reference: 'NSUInteger',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -1292,7 +1320,8 @@ describe('AlgebraicTypePlugins.Description', function() {
               reference: 'CGRect',
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -1334,7 +1363,8 @@ describe('AlgebraicTypePlugins.Description', function() {
                   reference: 'NSString *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject')
+                  underlyingType: Maybe.Just<string>('NSObject'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               },
               {
@@ -1347,7 +1377,8 @@ describe('AlgebraicTypePlugins.Description', function() {
                   reference: 'NSUInteger',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -1363,7 +1394,8 @@ describe('AlgebraicTypePlugins.Description', function() {
               reference: 'BOOL',
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -1457,7 +1489,8 @@ describe('AlgebraicTypePlugins.Description', function() {
                   reference: 'Foo *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -1495,7 +1528,8 @@ describe('AlgebraicTypePlugins.Description', function() {
                   reference: 'Foo *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -1511,7 +1545,8 @@ describe('AlgebraicTypePlugins.Description', function() {
               reference: 'Ferr',
               libraryTypeIsDefinedIn: Maybe.Just<string>('SomeLib'),
               fileTypeIsDefinedIn: Maybe.Just<string>('SomethingElse'),
-              underlyingType: Maybe.Nothing<string>()
+              underlyingType: Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -1548,7 +1583,8 @@ describe('AlgebraicTypePlugins.Description', function() {
                   reference: 'Ferr',
                   libraryTypeIsDefinedIn: Maybe.Just<string>('SomeLib'),
                   fileTypeIsDefinedIn: Maybe.Just<string>('SomethingElse'),
-                  underlyingType: Maybe.Just<string>('SomethingRandom')
+                  underlyingType: Maybe.Just<string>('SomethingRandom'),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]

--- a/src/__tests__/plugins/equality-test.ts
+++ b/src/__tests__/plugins/equality-test.ts
@@ -51,7 +51,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -64,7 +65,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'LikeStatus',
               reference: 'LikeStatus',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -96,7 +98,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'Name',
               reference: 'Name',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -109,7 +112,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'LikeStatus',
               reference: 'LikeStatus',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -142,7 +146,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'FooBar',
               reference: 'FooBar',
-              underlyingType:Maybe.Just<string>('Baz')
+              underlyingType:Maybe.Just<string>('Baz'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -177,7 +182,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'SEL',
               reference: 'SEL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -190,7 +196,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -227,7 +234,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSUInteger',
               reference: 'NSUInteger',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -240,7 +248,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSInteger',
               reference: 'NSInteger',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -253,7 +262,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -266,7 +276,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'float',
               reference: 'float',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -279,7 +290,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'double',
               reference: 'double',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -292,7 +304,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'BOOL',
               reference: 'BOOL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -305,7 +318,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'CGFloat',
               reference: 'CGFloat',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -318,7 +332,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'CGRect',
               reference: 'CGRect',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -331,7 +346,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'CGPoint',
               reference: 'CGPoint',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -344,7 +360,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'CGSize',
               reference: 'CGSize',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -357,7 +374,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'UIEdgeInsets',
               reference: 'UIEdgeInsets',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -370,7 +388,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSRange',
               reference: 'NSRange',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -475,7 +494,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'double',
               reference: 'double',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -488,7 +508,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'id',
               reference: 'id',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
         ],
@@ -621,7 +642,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'float',
               reference: 'float',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -725,7 +747,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'float',
               reference: 'float',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -738,7 +761,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'float',
               reference: 'float',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -842,7 +866,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'Derrrpppppp',
               reference: 'Derrrpppppp',
-              underlyingType:Maybe.Just<string>('double')
+              underlyingType:Maybe.Just<string>('double'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -937,7 +962,8 @@ describe('ObjectSpecPlugins.Equality', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'CGFloat',
               reference: 'CGFloat',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1208,7 +1234,8 @@ describe('AlgebraicTypePlugins.Equality', function() {
               reference: 'Foo *',
               libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Nothing<string>()
+              underlyingType: Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]
@@ -1245,7 +1272,8 @@ describe('AlgebraicTypePlugins.Equality', function() {
                   reference: 'Foo *',
                   libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
                   fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -1265,7 +1293,8 @@ describe('AlgebraicTypePlugins.Equality', function() {
                   reference: 'Ferr',
                   libraryTypeIsDefinedIn: Maybe.Just<string>('SomeLib'),
                   fileTypeIsDefinedIn: Maybe.Just<string>('SomethingElse'),
-                  underlyingType: Maybe.Nothing<string>()
+                  underlyingType: Maybe.Nothing<string>(),
+                  conformingProtocol: Maybe.Nothing<string>()
                 }
               }
             ]
@@ -1301,7 +1330,8 @@ describe('AlgebraicTypePlugins.Equality', function() {
               reference: 'Ferr',
               libraryTypeIsDefinedIn: Maybe.Just<string>('SomeLib'),
               fileTypeIsDefinedIn: Maybe.Just<string>('SomethingElse'),
-              underlyingType: Maybe.Just<string>('SomethingRandom')
+              underlyingType: Maybe.Just<string>('SomethingRandom'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           })
         ]

--- a/src/__tests__/plugins/fetch-status-test.ts
+++ b/src/__tests__/plugins/fetch-status-test.ts
@@ -44,7 +44,8 @@ describe('Plugins.FetchStatus', function() {
           libraryTypeIsDefinedIn:Maybe.Just<string>('FooLib'),
           name:'FooFetchStatus',
           reference: 'FooFetchStatus *',
-          underlyingType:Maybe.Just<string>('NSObject')
+          underlyingType:Maybe.Just<string>('NSObject'),
+          conformingProtocol: Maybe.Nothing<string>()
         }
       }];
 
@@ -66,7 +67,8 @@ describe('Plugins.FetchStatus', function() {
             libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
             name: 'NSUInteger',
             reference: 'NSUInteger',
-            underlyingType:Maybe.Nothing<string>()
+            underlyingType:Maybe.Nothing<string>(),
+            conformingProtocol: Maybe.Nothing<string>()
           }
         }
         ],
@@ -93,7 +95,8 @@ describe('Plugins.FetchStatus', function() {
             libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
             name:'BOOL',
             reference: 'BOOL',
-            underlyingType:Maybe.Nothing<string>()
+            underlyingType:Maybe.Nothing<string>(),
+            conformingProtocol: Maybe.Nothing<string>()
           }
         }
         ],

--- a/src/__tests__/plugins/immutable-properties-test.ts
+++ b/src/__tests__/plugins/immutable-properties-test.ts
@@ -53,7 +53,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -116,7 +117,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -179,7 +181,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:null,
               name:'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -192,7 +195,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:null,
               name:'BOOL',
               reference: 'BOOL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -205,7 +209,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:null,
               name:'RMAnotherSomething',
               reference: 'RMAnotherSomething *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -218,7 +223,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:null,
               name:'id',
               reference: 'id',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -317,7 +323,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:null,
               name:'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -330,7 +337,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:null,
               name:'BOOL',
               reference: 'BOOL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -343,7 +351,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:null,
               name:'RMAnotherSomething',
               reference: 'RMAnotherSomething *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -356,7 +365,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:null,
               name:'id',
               reference: 'id',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -597,7 +607,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'RMSomethingElse',
               reference: 'RMSomethingElse *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -635,7 +646,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'RMSomethingElse',
               reference: 'RMSomethingElse *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -673,7 +685,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'RMSomethingElse',
               reference: 'RMSomethingElse *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -711,7 +724,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Just('RMSomeOtherLibrary'),
               name:'RMSomethingElse',
               reference: 'RMSomethingElse *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -749,7 +763,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Just('RMSomeOtherLibrary'),
               name:'RMSomethingElse',
               reference: 'RMSomethingElse *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -787,7 +802,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Just('RMSomeOtherLibrary'),
               name:'RMSomethingElse',
               reference: 'RMSomethingElse *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -824,7 +840,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'BOOL',
               reference: 'BOOL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -860,7 +877,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'double',
               reference: 'double',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -896,7 +914,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'float',
               reference: 'float',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -932,7 +951,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSTimeInterval',
               reference: 'NSTimeInterval',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -968,7 +988,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'CGFloat',
               reference: 'CGFloat',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1005,7 +1026,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'CGRect',
               reference: 'CGRect',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1042,7 +1064,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'CGPoint',
               reference: 'CGPoint',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1079,7 +1102,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'SEL',
               reference: 'SEL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1115,7 +1139,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'CGSize',
               reference: 'CGSize',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1152,7 +1177,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'UIEdgeInsets',
               reference: 'UIEdgeInsets',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1189,7 +1215,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'int32_t',
               reference: 'int32_t',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1225,7 +1252,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'int64_t',
               reference: 'int64_t',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1261,7 +1289,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'uint32_t',
               reference: 'uint32_t',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1297,7 +1326,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'uint64_t',
               reference: 'uint64_t',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1333,7 +1363,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSUInteger',
               reference: 'NSUInteger',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1369,7 +1400,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSInteger',
               reference: 'NSInteger',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1405,7 +1437,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1460,7 +1493,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'BOOL',
               reference: 'BOOL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1504,7 +1538,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'RMSomething',
               reference: 'RMSomething *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1549,7 +1584,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'RMSomething',
               reference: 'RMSomething *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1592,7 +1628,8 @@ describe('Plugins.ImmutableProperties', function() {
           libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
           name:'RMSomething',
           reference: 'RMSomething *',
-          underlyingType:Maybe.Just<string>('NSObject')
+          underlyingType:Maybe.Just<string>('NSObject'),
+          conformingProtocol: Maybe.Nothing<string>()
         }
       };
 
@@ -1611,7 +1648,8 @@ describe('Plugins.ImmutableProperties', function() {
           libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
           name:'RMSomething',
           reference: 'RMSomething *',
-          underlyingType:Maybe.Just<string>('NSObject')
+          underlyingType:Maybe.Just<string>('NSObject'),
+          conformingProtocol: Maybe.Nothing<string>()
         }
       };
 
@@ -1630,7 +1668,8 @@ describe('Plugins.ImmutableProperties', function() {
           libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
           name:'Foo',
           reference: 'Foo',
-          underlyingType:Maybe.Just<string>('NSUInteger')
+          underlyingType:Maybe.Just<string>('NSUInteger'),
+          conformingProtocol: Maybe.Nothing<string>()
         }
       };
 
@@ -1649,7 +1688,8 @@ describe('Plugins.ImmutableProperties', function() {
           libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
           name:'RMSomething',
           reference: 'RMSomething *',
-          underlyingType:Maybe.Just<string>('NSObject')
+          underlyingType:Maybe.Just<string>('NSObject'),
+          conformingProtocol: Maybe.Nothing<string>()
         }
       };
 
@@ -1668,7 +1708,8 @@ describe('Plugins.ImmutableProperties', function() {
           libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
           name:'RMSomething',
           reference: 'RMSomething *',
-          underlyingType:Maybe.Just<string>('NSObject')
+          underlyingType:Maybe.Just<string>('NSObject'),
+          conformingProtocol: Maybe.Nothing<string>()
         }
       };
 
@@ -1693,7 +1734,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'RMSomething',
               reference: 'RMSomething *',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1726,7 +1768,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'Foo',
               reference: 'Foo *',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -1766,7 +1809,8 @@ describe('Plugins.ImmutableProperties', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'Foo',
               reference: 'Foo *',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],

--- a/src/__tests__/value-object-code-utils-test.ts
+++ b/src/__tests__/value-object-code-utils-test.ts
@@ -70,7 +70,8 @@ describe('ObjectSpecCodeUtils', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -101,7 +102,8 @@ describe('ObjectSpecCodeUtils', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSUInteger',
               reference: 'NSUInteger',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -132,7 +134,8 @@ describe('ObjectSpecCodeUtils', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSString',
               reference: 'NSString *',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -145,7 +148,8 @@ describe('ObjectSpecCodeUtils', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name: 'NSUInteger',
               reference: 'NSUInteger',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],

--- a/src/__tests__/value-object-parser-test.ts
+++ b/src/__tests__/value-object-parser-test.ts
@@ -38,7 +38,8 @@ describe('ObjectSpecParser', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'NSArray',
               reference: 'NSArray*',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -51,7 +52,8 @@ describe('ObjectSpecParser', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'BOOL',
               reference: 'BOOL',
-              underlyingType:Maybe.Nothing<string>()
+              underlyingType:Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -117,7 +119,8 @@ describe('ObjectSpecParser', function() {
               libraryTypeIsDefinedIn:Maybe.Just('RMCustomLibrary'),
               name:'RMBlah',
               reference: 'RMBlah*',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -130,7 +133,8 @@ describe('ObjectSpecParser', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'RMSomeValue',
               reference: 'RMSomeValue',
-              underlyingType:Maybe.Just('BOOL')
+              underlyingType:Maybe.Just('BOOL'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],
@@ -190,7 +194,8 @@ describe('ObjectSpecParser', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'RMBlah',
               reference: 'RMBlah*',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           },
           {
@@ -207,7 +212,8 @@ describe('ObjectSpecParser', function() {
               libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
               name:'RMBlah',
               reference: 'RMBlah*',
-              underlyingType:Maybe.Just<string>('NSObject')
+              underlyingType:Maybe.Just<string>('NSObject'),
+              conformingProtocol: Maybe.Nothing<string>()
             }
           }
         ],

--- a/src/algebraic-type-parser.ts
+++ b/src/algebraic-type-parser.ts
@@ -35,9 +35,10 @@ function subtypeAttributeTypeFromParsedAttribtueType(type:ObjectMonaParser.Parse
   return {
     fileTypeIsDefinedIn:ObjectGenerationParsingUtils.valueFromImportAnnotationFromAnnotations(annotations, 'file'),
     libraryTypeIsDefinedIn:ObjectGenerationParsingUtils.valueFromImportAnnotationFromAnnotations(annotations, 'library'),
-    name:type.reference.replace('*',''),
+    name:type.name,
     reference:type.reference,
-    underlyingType:underlyingTypeForType(type.underlyingType, type.reference)
+    underlyingType:underlyingTypeForType(type.underlyingType, type.reference),
+    conformingProtocol: ObjectGenerationParsingUtils.possiblyUndefinedStringToMaybe(type.conformingProtocol)
   };
 }
 

--- a/src/algebraic-type.ts
+++ b/src/algebraic-type.ts
@@ -20,6 +20,7 @@ export interface SubtypeAttributeType {
   name:string;
   reference:string;
   underlyingType:Maybe.Maybe<string>;
+  conformingProtocol:Maybe.Maybe<string>;
 }
 
 export interface SubtypeAttribute {

--- a/src/js/object-mona-parser/object-mona-parser.d.ts
+++ b/src/js/object-mona-parser/object-mona-parser.d.ts
@@ -56,8 +56,10 @@ export interface AlgebraicTypeParseResult {
 
 export interface ParsedAttributeType {
   isNSObject:boolean;
+  name:string;
   reference:string;
   underlyingType:string;
+  conformingProtocol:string;
 }
 
 export interface ParsedAttribute {

--- a/src/object-spec-parser.ts
+++ b/src/object-spec-parser.ts
@@ -35,9 +35,10 @@ function foundAttributeTypeFromParsedAttributeType(type:ObjectMonaParser.ParsedA
   return {
     fileTypeIsDefinedIn:ObjectGenerationParsingUtils.valueFromImportAnnotationFromAnnotations(annotations, 'file'),
     libraryTypeIsDefinedIn:ObjectGenerationParsingUtils.valueFromImportAnnotationFromAnnotations(annotations, 'library'),
-    name:type.reference.replace('*',''),
+    name:type.name,
     reference:type.reference,
-    underlyingType:underlyingTypeForType(type.underlyingType, type.reference)
+    underlyingType:underlyingTypeForType(type.underlyingType, type.reference),
+    conformingProtocol: ObjectGenerationParsingUtils.possiblyUndefinedStringToMaybe(type.conformingProtocol)
   };
 }
 

--- a/src/object-spec.ts
+++ b/src/object-spec.ts
@@ -20,6 +20,7 @@ export interface AttributeType {
   name:string;
   reference:string;
   underlyingType:Maybe.Maybe<string>;
+  conformingProtocol:Maybe.Maybe<string>;
 }
 
 export interface Attribute {

--- a/src/plugins/fetch-status.ts
+++ b/src/plugins/fetch-status.ts
@@ -39,7 +39,8 @@ function fetchStatusAttributeForAttribute(attribute:ObjectSpec.Attribute):Object
       libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
       name:'BOOL',
       reference:'BOOL',
-      underlyingType:Maybe.Nothing<string>()
+      underlyingType:Maybe.Nothing<string>(),
+      conformingProtocol:Maybe.Nothing<string>()
     }
   };
 }
@@ -76,7 +77,8 @@ function fetchStatusAttributeForValueType(objectType:ObjectSpec.Type):ObjectSpec
       libraryTypeIsDefinedIn:objectType.libraryName,
       name:fetchStatusTypeName,
       reference:ObjectSpecUtils.typeReferenceForValueTypeWithName(fetchStatusTypeName),
-      underlyingType:Maybe.Just<string>('NSObject')
+      underlyingType:Maybe.Just<string>('NSObject'),
+      conformingProtocol:Maybe.Nothing<string>()
     }
   };
 }

--- a/src/plugins/immutable-properties.ts
+++ b/src/plugins/immutable-properties.ts
@@ -150,7 +150,7 @@ function isImportRequiredForAttribute(typeLookups:ObjectGeneration.TypeLookup[],
 }
 
 function isImportRequiredForTypeLookup(objectType:ObjectSpec.Type, typeLookup:ObjectGeneration.TypeLookup):boolean {
-  return !isForwardDeclarationRequiredForTypeLookup(objectType, typeLookup);
+  return typeLookup.name !== objectType.typeName;
 }
 
 function importForAttribute(objectLibrary:Maybe.Maybe<string>, isPublic:boolean, attribute:ObjectSpec.Attribute):ObjC.Import {

--- a/src/plugins/immutable-properties.ts
+++ b/src/plugins/immutable-properties.ts
@@ -160,6 +160,10 @@ function isImportRequiredForTypeLookup(objectType:ObjectSpec.Type, typeLookup:Ob
   return typeLookup.name !== objectType.typeName;
 }
 
+function importForTypeLookup(objectLibrary:Maybe.Maybe<string>, isPublic:boolean, typeLookup:ObjectGeneration.TypeLookup):ObjC.Import {
+  return ObjCImportUtils.importForTypeLookup(objectLibrary, isPublic || !typeLookup.canForwardDeclare, typeLookup);
+}
+
 function importForAttribute(objectLibrary:Maybe.Maybe<string>, isPublic:boolean, attribute:ObjectSpec.Attribute):ObjC.Import {
   const builtInImportMaybe:Maybe.Maybe<ObjC.Import> = ObjCImportUtils.typeDefinitionImportForKnownSystemType(attribute.type.name);
 
@@ -186,7 +190,7 @@ function skipAttributePrivateImportsForValueType(objectType:ObjectSpec.Type):boo
 }
 
 function isForwardDeclarationRequiredForTypeLookup(objectType:ObjectSpec.Type, typeLookup:ObjectGeneration.TypeLookup):boolean {
-  return typeLookup.name === objectType.typeName || !makePublicImportsForValueType(objectType);
+  return typeLookup.name === objectType.typeName || (typeLookup.canForwardDeclare && !makePublicImportsForValueType(objectType));
 }
 
 function forwardDeclarationForTypeLookup(typeLookup:ObjectGeneration.TypeLookup):ObjC.ForwardDeclaration {
@@ -268,7 +272,7 @@ export function createPlugin():ObjectSpec.Plugin {
       const makePublicImports = makePublicImportsForValueType(objectType);
       const skipAttributeImports = !makePublicImports && skipAttributePrivateImportsForValueType(objectType);
       const typeLookupImports = objectType.typeLookups.filter(FunctionUtils.pApplyf2(objectType, isImportRequiredForTypeLookup))
-                                                      .map(FunctionUtils.pApply2f3(objectType.libraryName, makePublicImports, ObjCImportUtils.importForTypeLookup));
+                                                      .map(FunctionUtils.pApply2f3(objectType.libraryName, makePublicImports, importForTypeLookup));
       const attributeImports = skipAttributeImports
         ? []
         : objectType.attributes.filter(FunctionUtils.pApplyf2(objectType.typeLookups, isImportRequiredForAttribute))


### PR DESCRIPTION
The goal of this stack of diffs is to be able to forward declare protocols, and to be able to generate the following .object file without any imports using 'skipAttributePrivateImports':

Existing UseForwardDeclarations with protocols
```
    %import name=UIViewController library=UIKit
    TestObj includes(UseForwardDeclarations) {
        %import library=HelloKit file=HelloProtocol
        id<HelloProtocol> helloObj
        %import library=WorldKit file=HWorldProtocol
        UIViewController<WorldProtocol> *worldVc
    }
```

header file:
```
    @class UIViewController;
    @protocol HelloProtocol;
    @protocol WorldProtocol;
```
implementation file:
```
    #import "TestObj.h"
    #import <UIKit/UIViewController.h>
    #import <HelloKit/HelloProtocol.h>
    #import <WorldKit/HWorldProtocol.h>
```

Usage with skipAttributePrivateImports (Note I haven't added a test case for this usage yet, I will after PR #45 is merged and I can rebase)
```
    TestObj includes(UseForwardDeclarations, skipAttributePrivateImports) {
        id<HelloProtocol> helloObj
        UIViewController<WorldProtocol> *worldVc
    }
```

header file:
```
    @class UIViewController;
    @protocol HelloProtocol;
    @protocol WorldProtocol;
```
implementation file:
```
    #import "TestObj.h"
```