### PR TITLE
Add compiler-attribute support to Objc.Method and use NS_DESIGNATED_INITIALIZER

### DIFF
--- a/features/assume-nonnull.feature
+++ b/features/assume-nonnull.feature
@@ -26,7 +26,7 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
       @property (nonatomic, readonly, copy) NSString *aString;
       @property (nonatomic, readonly, copy, nullable) NSString *bString;
 
-      - (instancetype)initWithAString:(NSString *)aString bString:(nullable NSString *)bString;
+      - (instancetype)initWithAString:(NSString *)aString bString:(nullable NSString *)bString NS_DESIGNATED_INITIALIZER;
 
       @end
 

--- a/features/coding.feature
+++ b/features/coding.feature
@@ -27,7 +27,7 @@ Feature: Outputting Value Objects With Coded Values
       @property (nonatomic, readonly) NSInteger likeCount;
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings NS_DESIGNATED_INITIALIZER;
 
       @end
 

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -99,7 +99,7 @@ Feature: Outputting Value Objects With A Custom Plugin
       @property (nonatomic, readonly) NSInteger likeCount;
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings NS_DESIGNATED_INITIALIZER;
 
       @end
 

--- a/features/cplusplus.feature
+++ b/features/cplusplus.feature
@@ -39,7 +39,7 @@ Feature: Outputting C++ Value Objects
       @property (nonatomic, readonly) NSInteger likeCount;
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings NS_DESIGNATED_INITIALIZER;
 
       @end
 

--- a/features/fetch-status.feature
+++ b/features/fetch-status.feature
@@ -32,7 +32,7 @@ Feature: Outputting Value Objects
       @property (nonatomic, readonly) BOOL hasFetchedSomeEnumValue;
       @property (nonatomic, readonly) BOOL hasFetchedCustomLibObject;
 
-      - (instancetype)initWithHasFetchedDoesUserLike:(BOOL)hasFetchedDoesUserLike hasFetchedIdentifier:(BOOL)hasFetchedIdentifier hasFetchedLikeCount:(BOOL)hasFetchedLikeCount hasFetchedRating:(BOOL)hasFetchedRating hasFetchedSomeEnumValue:(BOOL)hasFetchedSomeEnumValue hasFetchedCustomLibObject:(BOOL)hasFetchedCustomLibObject;
+      - (instancetype)initWithHasFetchedDoesUserLike:(BOOL)hasFetchedDoesUserLike hasFetchedIdentifier:(BOOL)hasFetchedIdentifier hasFetchedLikeCount:(BOOL)hasFetchedLikeCount hasFetchedRating:(BOOL)hasFetchedRating hasFetchedSomeEnumValue:(BOOL)hasFetchedSomeEnumValue hasFetchedCustomLibObject:(BOOL)hasFetchedCustomLibObject NS_DESIGNATED_INITIALIZER;
 
       @end
 

--- a/features/forward-declaration.feature
+++ b/features/forward-declaration.feature
@@ -57,7 +57,7 @@ Feature: Outputting Value Objects With Forward Declarations
       @property (nonatomic, readonly, copy) id<HelloProtocol> helloObj;
       @property (nonatomic, readonly, copy) UIViewController<WorldProtocol> *worldVc;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy followers:(NSArray<RMSomeType *> *)followers helloObj:(id<HelloProtocol>)helloObj worldVc:(UIViewController<WorldProtocol> *)worldVc;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(NSUInteger)numberOfRatings proxy:(RMProxy *)proxy followers:(NSArray<RMSomeType *> *)followers helloObj:(id<HelloProtocol>)helloObj worldVc:(UIViewController<WorldProtocol> *)worldVc NS_DESIGNATED_INITIALIZER;
 
       @end
 
@@ -185,7 +185,7 @@ Feature: Outputting Value Objects With Forward Declarations
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
       @property (nonatomic, readonly, copy) Foo *foo;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings foo:(Foo *)foo;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings foo:(Foo *)foo NS_DESIGNATED_INITIALIZER;
 
       @end
 

--- a/features/generics.feature
+++ b/features/generics.feature
@@ -21,7 +21,7 @@ Feature: Outputting Objects With Generic Types
 
       @property (nonatomic, readonly, copy) NSDictionary<NSString *, NSNumber *> *namesToAges;
 
-      - (instancetype)initWithNamesToAges:(NSDictionary<NSString *, NSNumber *> *)namesToAges;
+      - (instancetype)initWithNamesToAges:(NSDictionary<NSString *, NSNumber *> *)namesToAges NS_DESIGNATED_INITIALIZER;
 
       @end
 

--- a/features/nullability.feature
+++ b/features/nullability.feature
@@ -25,7 +25,7 @@ Feature: Outputting Objects With Nullability Annotations
       @property (nonatomic, readonly, copy, nullable) NSString *name;
       @property (nonatomic, readonly, copy, nonnull) NSString *identifier;
 
-      - (instancetype)initWithName:(nullable NSString *)name identifier:(nonnull NSString *)identifier;
+      - (instancetype)initWithName:(nullable NSString *)name identifier:(nonnull NSString *)identifier NS_DESIGNATED_INITIALIZER;
 
       @end
 

--- a/features/object.feature
+++ b/features/object.feature
@@ -48,7 +48,7 @@ Feature: Outputting Objects
       @property (nonatomic, readonly, unsafe_unretained) Class someClass;
       @property (nonatomic, readonly) dispatch_block_t someBlock;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(uint32_t)numberOfRatings someType:(RMSomeType *)someType someClass:(Class)someClass someBlock:(dispatch_block_t)someBlock;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(uint32_t)numberOfRatings someType:(RMSomeType *)someType someClass:(Class)someClass someBlock:(dispatch_block_t)someBlock NS_DESIGNATED_INITIALIZER;
 
       @end
 
@@ -123,7 +123,7 @@ Feature: Outputting Objects
       @property (nonatomic, readonly) CGFloat countIconWidth;
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings NS_DESIGNATED_INITIALIZER;
 
       @end
 

--- a/features/value_object.feature
+++ b/features/value_object.feature
@@ -48,7 +48,7 @@ Feature: Outputting Value Objects
       @property (nonatomic, readonly, unsafe_unretained) Class someClass;
       @property (nonatomic, readonly, copy) dispatch_block_t someBlock;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(uint32_t)numberOfRatings someType:(RMSomeType *)someType someClass:(Class)someClass someBlock:(dispatch_block_t)someBlock;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount numberOfRatings:(uint32_t)numberOfRatings someType:(RMSomeType *)someType someClass:(Class)someClass someBlock:(dispatch_block_t)someBlock NS_DESIGNATED_INITIALIZER;
 
       @end
 
@@ -165,7 +165,7 @@ Feature: Outputting Value Objects
       @property (nonatomic, readonly) CGFloat countIconWidth;
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
 
-      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings;
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier likeCount:(NSInteger)likeCount countIconHeight:(CGFloat)countIconHeight countIconWidth:(CGFloat)countIconWidth numberOfRatings:(NSUInteger)numberOfRatings NS_DESIGNATED_INITIALIZER;
 
       @end
 

--- a/src/__tests__/objc-renderer-test.ts
+++ b/src/__tests__/objc-renderer-test.ts
@@ -50,6 +50,7 @@ describe('ObjCRenderer', function() {
                   'return [[RMSomeValue alloc] init];'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'someClassMethodWithValue1',
@@ -95,6 +96,7 @@ describe('ObjCRenderer', function() {
                   'return self;'
                 ],
                 comments:[],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'initWithValue1',
@@ -130,6 +132,7 @@ describe('ObjCRenderer', function() {
                   'return 0;'
                 ],
                 comments:[],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'hash',
@@ -280,6 +283,7 @@ describe('ObjCRenderer', function() {
                   'return [[RMSomeValue alloc] init];'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'someClassMethodWithValue1',
@@ -323,6 +327,7 @@ describe('ObjCRenderer', function() {
                   'return self;'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'initWithValue1',
@@ -358,6 +363,7 @@ describe('ObjCRenderer', function() {
                   'return 0;'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'hash',
@@ -483,6 +489,7 @@ describe('ObjCRenderer', function() {
                   'return [[RMSomeValue alloc] init];'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'someClassMethodWithValue1',
@@ -526,6 +533,7 @@ describe('ObjCRenderer', function() {
                   'return self;'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'initWithValue1',
@@ -561,6 +569,7 @@ describe('ObjCRenderer', function() {
                   'return 0;'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'hash',
@@ -689,6 +698,7 @@ describe('ObjCRenderer', function() {
                   'return self;'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'initWithValue',
@@ -735,6 +745,7 @@ describe('ObjCRenderer', function() {
                   'return 0;'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'hash',
@@ -845,6 +856,7 @@ describe('ObjCRenderer', function() {
                   'return self;'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'initWithValue1',
@@ -878,6 +890,7 @@ describe('ObjCRenderer', function() {
                 belongsToProtocol:Maybe.Just('NSObject'),
                 code:['return 0;'],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'hash',
@@ -1540,6 +1553,7 @@ describe('ObjCRenderer', function() {
                 belongsToProtocol:Maybe.Nothing<string>(),
                 code:[],
                 comments: [ { content: '// Check this method out!!!!' }],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'doSomething',
@@ -1658,6 +1672,118 @@ describe('ObjCRenderer', function() {
 
       expect(renderedOutput).toEqualJSON(expectedOutput);
     });
+
+    it('renders a header containing the given method compiler attributes', function() {
+      const fileToRender:Code.File = {
+        name: 'RMSomeValue',
+        type: Code.FileType.ObjectiveC(),
+        imports:[],
+        comments:[],
+        enumerations: [],
+        blockTypes:[],
+        staticConstants: [],
+        functions: [],
+        forwardDeclarations: [],
+        diagnosticIgnores:[],
+        classes: [
+          {
+            baseClassName:'NSObject',
+            classMethods: [],
+            comments:[],
+            instanceMethods: [
+              {
+                belongsToProtocol:Maybe.Nothing<string>(),
+                code:[
+                  'if (self = [super init]) {',
+                  '  _value1 = value1;',
+                  '  _value2 = value2;',
+                  '}',
+                  '',
+                  'return self;'
+                ],
+                comments:[],
+                compilerAttributes:[
+                  'NS_DESIGNATED_INITIALIZER'
+                ],
+                keywords: [
+                  {
+                    name:'initWithValue1',
+                    argument:Maybe.Just({
+                      name:'value1',
+                      modifiers: [],
+                      type: {
+                        name:'RMSomething',
+                        reference:'RMSomething *'
+                      }
+                    })
+                  },
+                  {
+                    name:'value2',
+                    argument:Maybe.Just({
+                      name:'value2',
+                      modifiers: [],
+                      type: {
+                        name:'RMSomething',
+                        reference:'RMSomething *'
+                      }
+                    })
+                  }
+                ],
+                returnType: Maybe.Just({
+                  name:'instancetype',
+                  reference:'instancetype'
+                })
+              }
+            ],
+            name:'RMSomeValue',
+            properties: [
+              {
+                comments:[],
+                modifiers:[ObjC.PropertyModifier.Nonatomic(), ObjC.PropertyModifier.Readonly()],
+                access: ObjC.PropertyAccess.Public(),
+                name:'value1',
+                returnType: {
+                  name:'RMSomething',
+                  reference:'RMSomething *'
+                }
+              },
+              {
+                comments:[],
+                modifiers:[ObjC.PropertyModifier.Nonatomic(), ObjC.PropertyModifier.Readonly()],
+                access: ObjC.PropertyAccess.Public(),
+                name:'value2',
+                returnType: {
+                  name:'RMSomething',
+                  reference:'RMSomething *'
+                }
+              }
+            ],
+            internalProperties:[],
+            implementedProtocols:[],
+            nullability: ObjC.ClassNullability.default
+          }
+        ],
+        structs: [],
+        namespaces: []
+      };
+
+      const renderedOutput:Maybe.Maybe<string> = ObjCRenderer.renderHeader(fileToRender);
+
+      const expectedOutput:Maybe.Maybe<string> = Maybe.Just<string>(
+        '@interface RMSomeValue : NSObject\n' +
+        '\n' +
+        '@property (nonatomic, readonly) RMSomething *value1;\n' +
+        '@property (nonatomic, readonly) RMSomething *value2;\n' +
+        '\n' +
+        '- (instancetype)initWithValue1:(RMSomething *)value1 value2:(RMSomething *)value2 NS_DESIGNATED_INITIALIZER;\n' +
+        '\n' +
+        '@end\n' +
+        '\n'
+      );
+
+      expect(renderedOutput).toEqualJSON(expectedOutput);
+    });
+
   });
 
   describe('#renderImplementation', function() {
@@ -1693,6 +1819,7 @@ describe('ObjCRenderer', function() {
                   'return [[RMSomeValue alloc] init];'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'someClassMethodWithValue1',
@@ -1736,6 +1863,7 @@ describe('ObjCRenderer', function() {
                   'return self;'
                 ],
                 comments: [],
+                compilerAttributes:[],
                 keywords: [
                   {
                     name:'initWithValue1',
@@ -1950,6 +2078,7 @@ describe('ObjCRenderer', function() {
               'return self;'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
             {
               name:'initWithValue1',

--- a/src/__tests__/plugins/algebraic-type-function-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-function-matching-test.ts
@@ -214,6 +214,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
           '  }',
           '}'
         ],
+        compilerAttributes:[],
         comments: [],
         keywords: [
           {

--- a/src/__tests__/plugins/algebraic-type-initialization-test.ts
+++ b/src/__tests__/plugins/algebraic-type-initialization-test.ts
@@ -272,6 +272,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             'return object;'
           ],
           comments: [],
+          compilerAttributes:[],
           keywords: [
             {
               name: 'someSubtype',
@@ -363,6 +364,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             'return object;'
           ],
           comments: [],
+          compilerAttributes:[],
           keywords: [
             {
               name: 'someSubtypeWithSomeString',
@@ -401,6 +403,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
             'return object;'
           ],
           comments: [],
+          compilerAttributes:[],
           keywords: [
             {
               name: 'singleAttributeSubtype',

--- a/src/__tests__/plugins/builder-test.ts
+++ b/src/__tests__/plugins/builder-test.ts
@@ -77,6 +77,7 @@ describe('Plugins.Builder', function() {
                     'return [[FooBarBazBuilder alloc] init];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'fooBarBaz',
@@ -94,6 +95,7 @@ describe('Plugins.Builder', function() {
                     'return [FooBarBazBuilder fooBarBaz];',
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'fooBarBazFromExistingFooBarBaz',
@@ -121,6 +123,7 @@ describe('Plugins.Builder', function() {
                     'return [[FooBarBaz alloc] init];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'build',
@@ -204,6 +207,7 @@ describe('Plugins.Builder', function() {
                     'return [[RMFerrBuilder alloc] init];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'ferr',
@@ -221,6 +225,7 @@ describe('Plugins.Builder', function() {
                     'return [RMFerrBuilder ferr];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'ferrFromExistingFerr',
@@ -248,6 +253,7 @@ describe('Plugins.Builder', function() {
                     'return [[RMFerr alloc] init];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'build',
@@ -380,6 +386,7 @@ describe('Plugins.Builder', function() {
                     'return [[RMFerrBuilder alloc] init];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'ferr',
@@ -400,6 +407,7 @@ describe('Plugins.Builder', function() {
                     '        withSomeBool:existingFerr.someBool];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'ferrFromExistingFerr',
@@ -427,6 +435,7 @@ describe('Plugins.Builder', function() {
                     'return [[RMFerr alloc] initWithSomeUnsignedInteger:_someUnsignedInteger someCustomObject:_someCustomObject someBool:_someBool];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'build',
@@ -445,6 +454,7 @@ describe('Plugins.Builder', function() {
                     'return self;'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'withSomeUnsignedInteger',
@@ -470,6 +480,7 @@ describe('Plugins.Builder', function() {
                     'return self;'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'withSomeCustomObject',
@@ -495,6 +506,7 @@ describe('Plugins.Builder', function() {
                     'return self;'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'withSomeBool',
@@ -665,6 +677,7 @@ describe('Plugins.Builder', function() {
                     'return [[RMFerrBuilder alloc] init];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'ferr',
@@ -685,6 +698,7 @@ describe('Plugins.Builder', function() {
                     '        withSomeBool:existingFerr.someBool];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'ferrFromExistingFerr',
@@ -712,6 +726,7 @@ describe('Plugins.Builder', function() {
                     'return [[RMFerr alloc] initWithSomeUnsignedInteger:_someUnsignedInteger someCustomObject:_someCustomObject someBool:_someBool];'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'build',
@@ -730,6 +745,7 @@ describe('Plugins.Builder', function() {
                     'return self;'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'withSomeUnsignedInteger',
@@ -755,6 +771,7 @@ describe('Plugins.Builder', function() {
                     'return self;'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'withSomeCustomObject',
@@ -780,6 +797,7 @@ describe('Plugins.Builder', function() {
                     'return self;'
                   ],
                   comments: [],
+                  compilerAttributes:[],
                   keywords: [
                     {
                       name:'withSomeBool',

--- a/src/__tests__/plugins/coding-test.ts
+++ b/src/__tests__/plugins/coding-test.ts
@@ -251,6 +251,7 @@ describe('ObjectSpecPlugins.Coding', function() {
             'return self;'
           ],
           comments: [],
+          compilerAttributes:[],
           keywords: [
             {
               name: 'initWithCoder',
@@ -277,6 +278,7 @@ describe('ObjectSpecPlugins.Coding', function() {
             '[aCoder encodeObject:_someObject forKey:kSomeObjectKey];'
           ],
           comments: [],
+          compilerAttributes:[],
           keywords: [
             {
               name: 'encodeWithCoder',
@@ -782,6 +784,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
             'return self;'
           ],
           comments: [],
+          compilerAttributes:[],
           keywords: [
             {
               name: 'initWithCoder',
@@ -818,6 +821,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
             '}'
           ],
           comments: [],
+          compilerAttributes:[],
           keywords: [
             {
               name: 'encodeWithCoder',

--- a/src/__tests__/plugins/description-test.ts
+++ b/src/__tests__/plugins/description-test.ts
@@ -256,6 +256,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t doesUserLike: %@; \\n", [super description], _doesUserLike ? @"YES" : @"NO"];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -308,6 +309,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t name: %@; \\n", [super description], _name];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -360,6 +362,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t something: %@; \\n", [super description], _something];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -412,6 +415,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %zd; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -464,6 +468,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %tu; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -516,6 +521,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %lf; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -568,6 +574,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %f; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -620,6 +627,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %f; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -672,6 +680,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %lf; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -724,6 +733,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %ld; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -776,6 +786,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %llu; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -828,6 +839,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %d; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -880,6 +892,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %lld; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -933,6 +946,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t age: %tu; \\n", [super description], _age];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -985,6 +999,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t action: %@; \\n", [super description], NSStringFromSelector(_action)];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -1037,6 +1052,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t range: %@; \\n", [super description], NSStringFromRange(_range)];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -1089,6 +1105,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t rect: %@; \\n", [super description], NSStringFromCGRect(_rect)];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -1141,6 +1158,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t origin: %@; \\n", [super description], NSStringFromCGPoint(_origin)];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -1193,6 +1211,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t size: %@; \\n", [super description], NSStringFromCGSize(_size)];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -1244,6 +1263,7 @@ describe('ObjectSpecPlugins.Description', function() {
               'return [NSString stringWithFormat:@"%@ - \\n\\t insets: %@; \\n", [super description], NSStringFromUIEdgeInsets(_insets)];'
             ],
             comments: [],
+            compilerAttributes:[],
             keywords: [
               {
                 name: 'description',
@@ -1419,6 +1439,7 @@ describe('AlgebraicTypePlugins.Description', function() {
             '}'
           ],
           comments: [],
+          compilerAttributes:[],
           keywords: [
             {
               name: 'description',

--- a/src/__tests__/plugins/equality-test.ts
+++ b/src/__tests__/plugins/equality-test.ts
@@ -440,6 +440,7 @@ describe('ObjectSpecPlugins.Equality', function() {
             '  (_someString == object->_someString ? YES : [_someString isEqual:object->_someString]);'
           ],
           comments: [],
+          compilerAttributes:[],
           returnType: Maybe.Just({
             name: 'BOOL',
             reference: 'BOOL'
@@ -469,6 +470,7 @@ describe('ObjectSpecPlugins.Equality', function() {
             'return result;'
           ],
           comments: [],
+          compilerAttributes:[],
           returnType: Maybe.Just({
             name: 'NSUInteger',
             reference: 'NSUInteger'
@@ -550,6 +552,7 @@ describe('ObjectSpecPlugins.Equality', function() {
             '  (_something == object->_something ? YES : [_something isEqual:object->_something]);'
           ],
           comments: [],
+          compilerAttributes:[],
           returnType: Maybe.Just({
             name: 'BOOL',
             reference: 'BOOL'
@@ -579,6 +582,7 @@ describe('ObjectSpecPlugins.Equality', function() {
             'return result;'
           ],
           comments: [],
+          compilerAttributes:[],
           returnType: Maybe.Just({
             name: 'NSUInteger',
             reference: 'NSUInteger'

--- a/src/__tests__/plugins/immutable-properties-test.ts
+++ b/src/__tests__/plugins/immutable-properties-test.ts
@@ -79,6 +79,7 @@ describe('Plugins.ImmutableProperties', function() {
             'return self;'
           ],
           comments: [],
+          compilerAttributes:["NS_DESIGNATED_INITIALIZER"],
           keywords: [
             {
               name:'initWithValue',
@@ -143,6 +144,7 @@ describe('Plugins.ImmutableProperties', function() {
             'return self;'
           ],
           comments: [],
+          compilerAttributes:["NS_DESIGNATED_INITIALIZER"],
           keywords: [
             {
               name:'initWithValue',
@@ -252,6 +254,7 @@ describe('Plugins.ImmutableProperties', function() {
             'return self;'
           ],
           comments: [],
+          compilerAttributes:["NS_DESIGNATED_INITIALIZER"],
           keywords: [
             {
               name:'initWithValue',
@@ -394,6 +397,7 @@ describe('Plugins.ImmutableProperties', function() {
             'return self;'
           ],
           comments: [],
+          compilerAttributes:["NS_DESIGNATED_INITIALIZER"],
           keywords: [
             {
               name:'initWithValue',

--- a/src/__tests__/value-object-creation-test.ts
+++ b/src/__tests__/value-object-creation-test.ts
@@ -50,6 +50,7 @@ describe('ObjectSpecCreation', function() {
               code: [
                 'return [NSString stringWithFormat:@"%@ - \\n\\t age: %zd; \\n", [super description], _age];'
               ],
+              compilerAttributes:[],
               keywords: [
                 {
                   name: 'description',
@@ -416,6 +417,7 @@ describe('ObjectSpecCreation', function() {
             code: [
             'return @"foo";'
             ],
+            compilerAttributes:[],
             keywords: [
             {
               name: 'foo',
@@ -522,6 +524,7 @@ describe('ObjectSpecCreation', function() {
               code: [
                 'return @"something";'
               ],
+              compilerAttributes:[],
               keywords: [
                 {
                   name: 'getSomeString',
@@ -539,6 +542,7 @@ describe('ObjectSpecCreation', function() {
               code: [
                 'return [NSString stringWithFormat:@"%@ - \\n\\t age: %zd; \\n", [super description], _age];'
               ],
+              compilerAttributes:[],
               keywords: [
                 {
                   name: 'debugDescription',
@@ -556,6 +560,7 @@ describe('ObjectSpecCreation', function() {
               code: [
                 'return [self init];'
               ],
+              compilerAttributes:[],
               keywords: [
                 {
                   name: 'initSomethingElse',
@@ -896,6 +901,7 @@ describe('ObjectSpecCreation', function() {
               code: [
                 'return @"something";'
               ],
+              compilerAttributes:[],
               keywords: [
                 {
                   name: 'getSomeString',
@@ -913,6 +919,7 @@ describe('ObjectSpecCreation', function() {
               code: [
                 'return [NSString stringWithFormat:@"%@ - \\n\\t age: %zd; \\n", [super description], _age];'
               ],
+              compilerAttributes:[],
               keywords: [
                 {
                   name: 'debugDescription',
@@ -980,6 +987,7 @@ describe('ObjectSpecCreation', function() {
               code: [
                 'return [self init];'
               ],
+              compilerAttributes:[],
               keywords: [
                 {
                   name: 'initSomethingElse',
@@ -1122,6 +1130,7 @@ describe('ObjectSpecCreation', function() {
               code: [
                 'return @"something";'
               ],
+              compilerAttributes:[],
               keywords: [
                 {
                   name: 'getSomeString',
@@ -1139,6 +1148,7 @@ describe('ObjectSpecCreation', function() {
               code: [
                 'return [NSString stringWithFormat:@"%@ - \\n\\t age: %zd; \\n", [super description], _age];'
               ],
+              compilerAttributes:[],
               keywords: [
                 {
                   name: 'debugDescription',
@@ -1210,6 +1220,7 @@ describe('ObjectSpecCreation', function() {
               code: [
                 'return [self init];'
               ],
+              compilerAttributes:[],
               keywords: [
                 {
                   name: 'initSomethingElse',

--- a/src/objc-renderer.ts
+++ b/src/objc-renderer.ts
@@ -168,8 +168,9 @@ function toClassMethodHeaderString(method:ObjC.Method):string {
 function toInstanceMethodHeaderString(method:ObjC.Method):string {
   const methodComments = method.comments.map(toCommentString).join('\n');
   const methodCommentsSection = codeSectionForCodeStringWithoutExtraSpace(methodComments);
+  const designatedInitializerString = method.compilerAttributes.length > 0 ? " " + method.compilerAttributes.join(" ") : "";
 
-  return methodCommentsSection + '- (' + toTypeString(method.returnType) + ')' + method.keywords.map(toKeywordString).join(' ') + ';';
+  return methodCommentsSection + '- (' + toTypeString(method.returnType) + ')' + method.keywords.map(toKeywordString).join(' ') + designatedInitializerString + ';';
 }
 
 function toClassMethodImplementationString(method:ObjC.Method):string {

--- a/src/objc.ts
+++ b/src/objc.ts
@@ -96,6 +96,7 @@ export interface Method {
   belongsToProtocol:Maybe.Maybe<string>;
   code:string[];
   comments:Comment[];
+  compilerAttributes:string[];
   keywords:Keyword[];
   returnType:Maybe.Maybe<Type>;
 }

--- a/src/plugins/algebraic-type-function-matching.ts
+++ b/src/plugins/algebraic-type-function-matching.ts
@@ -40,6 +40,7 @@ function instanceMethodForMatchingSubtypesOfAlgebraicType(algebraicType:Algebrai
     belongsToProtocol:Maybe.Nothing<string>(),
     code: matcherCodeForAlgebraicType(algebraicType),
     comments: [],
+    compilerAttributes:[],
     keywords: instanceMethodKeywordsForMatchingSubtypesOfAlgebraicType(algebraicType),
     returnType: Maybe.Nothing<ObjC.Type>()
   };

--- a/src/plugins/algebraic-type-initialization.ts
+++ b/src/plugins/algebraic-type-initialization.ts
@@ -102,6 +102,7 @@ function initializationClassMethodForSubtype(algebraicType:AlgebraicType.Type, s
     belongsToProtocol:Maybe.Nothing<string>(),
     code: openingCode.concat(setterStatements).concat('return object;'),
     comments:[],
+    compilerAttributes:[],
     keywords: keywordsForSubtype(subtype),
     returnType: Maybe.Just<ObjC.Type>({
       name: 'instancetype',

--- a/src/plugins/builder.ts
+++ b/src/plugins/builder.ts
@@ -37,6 +37,7 @@ function builderClassMethodForValueType(objectType:ObjectSpec.Type):ObjC.Method 
       'return [[' + nameOfBuilderForValueTypeWithName(objectType.typeName) + ' alloc] init];'
     ],
     comments:[],
+    compilerAttributes:[],
     keywords: [
       {
         name: shortNameOfObjectToBuildForValueTypeWithName(objectType.typeName),
@@ -94,6 +95,7 @@ function builderFromExistingObjectClassMethodForValueType(objectType:ObjectSpec.
     belongsToProtocol:Maybe.Just('NSObject'),
     code: codeForBuilderFromExistingObjectClassMethodForValueType(objectType),
     comments:[],
+    compilerAttributes:[],
     keywords: [
       {
         name: shortNameOfObjectToBuildForValueTypeWithName(objectType.typeName) + 'FromExisting' + StringUtils.capitalize(shortNameOfObjectToBuildForValueTypeWithName(objectType.typeName)),
@@ -125,6 +127,7 @@ function buildObjectInstanceMethodForValueType(objectType:ObjectSpec.Type):ObjC.
       'return ' + ObjectSpecCodeUtils.methodInvocationForConstructor(objectType, valueGeneratorForInvokingInitializerWithAttribute) + ';'
     ],
     comments:[],
+    compilerAttributes:[],
     keywords: [
       {
         name:'build',
@@ -163,6 +166,7 @@ function withInstanceMethodForAttribute(supportsValueSemantics:boolean, attribut
       'return self;'
     ],
     comments:[],
+    compilerAttributes:[],
     keywords: [
       {
         name: keywordNameForAttribute(attribute),

--- a/src/plugins/coding.ts
+++ b/src/plugins/coding.ts
@@ -92,6 +92,7 @@ function decodeMethodWithCode(code:string[]):ObjC.Method {
     belongsToProtocol:Maybe.Just<string>('NSCoding'),
     code: initBlockWithInternalCode(code),
     comments:[],
+    compilerAttributes:[],
     keywords: [
       {
         name: 'initWithCoder',
@@ -117,6 +118,7 @@ function encodeMethodWithCode(code:string[]):ObjC.Method {
     belongsToProtocol:Maybe.Just('NSCoding'),
     code: code,
     comments:[],
+    compilerAttributes:[],
     keywords: [
       {
         name: 'encodeWithCoder',

--- a/src/plugins/copying.ts
+++ b/src/plugins/copying.ts
@@ -20,6 +20,7 @@ function copyInstanceMethod():ObjC.Method {
     belongsToProtocol:Maybe.Just<string>('NSCopying'),
     code: ['return self;'],
     comments:[],
+    compilerAttributes:[],
     keywords: [
       {
         name: 'copyWithZone',

--- a/src/plugins/description.ts
+++ b/src/plugins/description.ts
@@ -253,6 +253,7 @@ function descriptionInstanceMethodWithCode(code:string[]):ObjC.Method {
     belongsToProtocol:Maybe.Just('NSObject'),
     code: code,
     comments:[],
+    compilerAttributes:[],
     keywords: [
       {
         name: 'description',

--- a/src/plugins/equality.ts
+++ b/src/plugins/equality.ts
@@ -634,6 +634,7 @@ function isEqualInstanceMethod(typeName:string, generatedTypeEqualityInformation
     ],
     code: code,
     comments:[],
+    compilerAttributes:[],
     returnType: Maybe.Just({
       name: 'BOOL',
       reference: 'BOOL'
@@ -674,6 +675,7 @@ function hashInstanceMethod(generatedTypeEqualityInformation:GeneratedTypeEquali
       'return result;'
     ],
     comments:[],
+    compilerAttributes:[],
     returnType: Maybe.Just({
       name: 'NSUInteger',
       reference: 'NSUInteger'

--- a/src/plugins/immutable-properties.ts
+++ b/src/plugins/immutable-properties.ts
@@ -77,6 +77,7 @@ function initializerFromAttributes(supportsValueSemantics:boolean, attributes:Ob
     belongsToProtocol: Maybe.Nothing<string>(),
     code: initializerCodeFromAttributes(supportsValueSemantics, attributes),
     comments:[],
+    compilerAttributes:["NS_DESIGNATED_INITIALIZER"],
     keywords: keywords,
     returnType: Maybe.Just({
       name: 'instancetype',


### PR DESCRIPTION
- This adds compilerAttribute to Objc.Method. This lets us add an arbitrary string behind the method definition in the header, but before the semicolon. We could type this better - I'll listen to your feedback here.

- As first usage I'm adding NS_DESIGNATED_INITIALIZER to the immutable-properties plugin.
- I'd like to also add support to add `- (instancetype)init NS_UNAVAILABLE;` and `+ (instancetype)new NS_UNAVAILABLE` in a separate plugin. That might need some new logic too, since these methods should only appear in the header.