### PR TITLE
Add support for return type modifiers (nullable/nonnull)

### DIFF
--- a/features/algebraic-types-coding.feature
+++ b/features/algebraic-types-coding.feature
@@ -84,7 +84,7 @@ Feature: Outputting Algebraic Types
         return object;
       }
 
-      - (instancetype)initWithCoder:(NSCoder *)aDecoder
+      - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder
       {
         if ((self = [super init])) {
           NSString *codedSubtype = [aDecoder decodeObjectForKey:kCodedSubtypeKey];

--- a/features/coding.feature
+++ b/features/coding.feature
@@ -47,7 +47,7 @@ Feature: Outputting Value Objects With Coded Values
 
       @implementation RMPage
 
-      - (instancetype)initWithCoder:(NSCoder *)aDecoder
+      - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder
       {
         if ((self = [super init])) {
           _doesUserLike = [aDecoder decodeBoolForKey:kDoesUserLikeKey];

--- a/src/__tests__/objc-renderer-test.ts
+++ b/src/__tests__/objc-renderer-test.ts
@@ -75,10 +75,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               }
             ],
             comments:[
@@ -121,10 +121,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               },
               {
                 belongsToProtocol:Maybe.Just('NSObject'),
@@ -139,10 +139,10 @@ describe('ObjCRenderer', function() {
                     argument:Maybe.Nothing<ObjC.KeywordArgument>()
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'NSUInteger',
                   reference:'NSUInteger'
-                })
+                }), modifiers:[] }
               }
             ],
             name:'RMSomeValue',
@@ -308,10 +308,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               }
             ],
             comments:[],
@@ -352,10 +352,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               },
               {
                 belongsToProtocol:Maybe.Just('NSObject'),
@@ -370,10 +370,10 @@ describe('ObjCRenderer', function() {
                     argument:Maybe.Nothing<ObjC.KeywordArgument>()
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'NSUInteger',
                   reference:'NSUInteger'
-                })
+                }), modifiers:[] }
               }
             ],
             name:'RMSomeValue',
@@ -514,10 +514,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               }
             ],
             comments:[],
@@ -558,10 +558,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               },
               {
                 belongsToProtocol:Maybe.Just('NSObject'),
@@ -576,10 +576,10 @@ describe('ObjCRenderer', function() {
                     argument:Maybe.Nothing<ObjC.KeywordArgument>()
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'NSUInteger',
                   reference:'NSUInteger'
-                })
+                }), modifiers:[] }
               }
             ],
             name:'RMSomeValue',
@@ -734,10 +734,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               },
               {
                 belongsToProtocol:Maybe.Just('NSObject'),
@@ -752,10 +752,10 @@ describe('ObjCRenderer', function() {
                     argument:Maybe.Nothing<ObjC.KeywordArgument>()
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'NSUInteger',
                   reference:'NSUInteger'
-                })
+                }), modifiers:[] }
               }
             ],
             name:'RMSomeValue',
@@ -881,10 +881,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               },
               {
                 belongsToProtocol:Maybe.Just('NSObject'),
@@ -897,10 +897,10 @@ describe('ObjCRenderer', function() {
                     argument:Maybe.Nothing<ObjC.KeywordArgument>()
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'NSUInteger',
                   reference:'NSUInteger'
-                })
+                }), modifiers:[] }
               }
             ],
             name:'RMSomeValue',
@@ -1044,10 +1044,10 @@ describe('ObjCRenderer', function() {
                 name: 'num'
               }
             ],
-            returnType: Maybe.Just<ObjC.Type>({
+            returnType:{ type:Maybe.Just<ObjC.Type>({
               name: 'NSString',
               reference:'NSString *'
-            }),
+            }), modifiers:[] },
             code: [
               '#if SOMETHING',
               'return @"foo";',
@@ -1061,10 +1061,10 @@ describe('ObjCRenderer', function() {
               comments: [],
               name: 'AnotherPublicFunction',
               parameters: [],
-              returnType: Maybe.Just<ObjC.Type>({
+              returnType:{ type:Maybe.Just<ObjC.Type>({
                 name: 'NSUInteger',
                 reference:'NSUInteger'
-              }),
+              }), modifiers:[] },
               code: [
                 'return 17;'
               ],
@@ -1075,7 +1075,7 @@ describe('ObjCRenderer', function() {
             name: 'ANonPublicFunction',
             parameters: [
             ],
-            returnType: Maybe.Nothing<ObjC.Type>(),
+            returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
             code: [
               'something();'
             ],
@@ -1224,7 +1224,7 @@ describe('ObjCRenderer', function() {
                 nullability: ObjC.Nullability.Inherited()
               }
             ],
-            returnType: Maybe.Nothing<ObjC.Type>(),
+            returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
             isPublic: true,
             nullability: ObjC.ClassNullability.default
           },
@@ -1241,10 +1241,10 @@ describe('ObjCRenderer', function() {
                 nullability: ObjC.Nullability.Inherited()
               }
             ],
-            returnType: Maybe.Just<ObjC.Type>({
+            returnType:{ type:Maybe.Just<ObjC.Type>({
               name: 'Foo',
               reference:'Foo *'
-            }),
+            }), modifiers:[] },
             isPublic: true,
             nullability: ObjC.ClassNullability.default
           }
@@ -1313,7 +1313,7 @@ describe('ObjCRenderer', function() {
             name: 'ANonPublicFunction',
             parameters: [
             ],
-            returnType: Maybe.Nothing<ObjC.Type>(),
+            returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
             code: [
               'something();'
             ],
@@ -1560,7 +1560,7 @@ describe('ObjCRenderer', function() {
                     argument:Maybe.Nothing<ObjC.KeywordArgument>()
                   }
                 ],
-                returnType:Maybe.Nothing<ObjC.Type>()
+                returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] }
               }
             ],
             name:'RMSomeValue',
@@ -1729,10 +1729,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               }
             ],
             name:'RMSomeValue',
@@ -1844,10 +1844,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               }
             ],
             comments:[],
@@ -1888,10 +1888,10 @@ describe('ObjCRenderer', function() {
                     })
                   }
                 ],
-                returnType: Maybe.Just({
+                returnType:{ type:Maybe.Just({
                   name:'instancetype',
                   reference:'instancetype'
-                })
+                }), modifiers:[] }
               }
             ],
             name:'RMSomeValue',
@@ -2103,10 +2103,10 @@ describe('ObjCRenderer', function() {
               })
             }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name:'instancetype',
               reference:'instancetype'
-            })
+            }), modifiers:[] }
           }
           ],
           name:'RMSomeValue',
@@ -2208,10 +2208,10 @@ describe('ObjCRenderer', function() {
                 name: 'num'
               }
             ],
-            returnType: Maybe.Just<ObjC.Type>({
+            returnType:{ type:Maybe.Just<ObjC.Type>({
               name: 'NSString',
               reference:'NSString *'
-            }),
+            }), modifiers:[] },
             code: [
               '#if SOMETHING',
               'return @"foo";',
@@ -2226,7 +2226,7 @@ describe('ObjCRenderer', function() {
             name: 'ANonPublicFunction',
             parameters: [
             ],
-            returnType: Maybe.Nothing<ObjC.Type>(),
+            returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
             code: [
               'something();'
             ],
@@ -2410,7 +2410,7 @@ describe('ObjCRenderer', function() {
                 nullability: ObjC.Nullability.Inherited()
               }
             ],
-            returnType: Maybe.Nothing<ObjC.Type>(),
+            returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
             isPublic: true,
             nullability: ObjC.ClassNullability.default
           },
@@ -2427,10 +2427,10 @@ describe('ObjCRenderer', function() {
                 nullability: ObjC.Nullability.Inherited()
               }
             ],
-            returnType: Maybe.Just<ObjC.Type>({
+            returnType:{ type:Maybe.Just<ObjC.Type>({
               name: 'Foo',
               reference:'Foo *'
-            }),
+            }), modifiers:[] },
             isPublic: false,
             nullability: ObjC.ClassNullability.default
           }
@@ -2489,7 +2489,7 @@ describe('ObjCRenderer', function() {
                 nullability: ObjC.Nullability.Inherited()
               }
             ],
-            returnType: Maybe.Nothing<ObjC.Type>(),
+            returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
             isPublic: true,
             nullability: ObjC.ClassNullability.default
           }

--- a/src/__tests__/objc-renderer-test.ts
+++ b/src/__tests__/objc-renderer-test.ts
@@ -1784,6 +1784,118 @@ describe('ObjCRenderer', function() {
       expect(renderedOutput).toEqualJSON(expectedOutput);
     });
 
+    it('renders a header containing method return type modifiers', function() {
+      const fileToRender:Code.File = {
+        name: 'RMSomeValue',
+        type: Code.FileType.ObjectiveC(),
+        imports:[],
+        comments:[],
+        enumerations: [],
+        blockTypes:[],
+        staticConstants: [],
+        functions: [],
+        forwardDeclarations: [],
+        diagnosticIgnores:[],
+        classes: [
+          {
+            baseClassName:'NSObject',
+            classMethods: [],
+            comments:[],
+            instanceMethods: [
+              {
+                belongsToProtocol:Maybe.Nothing<string>(),
+                code:[
+                  'if (self = [super init]) {',
+                  '  _value1 = value1;',
+                  '  _value2 = value2;',
+                  '}',
+                  '',
+                  'return self;'
+                ],
+                comments:[],
+                compilerAttributes:[],
+                keywords: [
+                  {
+                    name:'initWithValue1',
+                    argument:Maybe.Just({
+                      name:'value1',
+                      modifiers: [],
+                      type: {
+                        name:'RMSomething',
+                        reference:'RMSomething *'
+                      }
+                    })
+                  },
+                  {
+                    name:'value2',
+                    argument:Maybe.Just({
+                      name:'value2',
+                      modifiers: [],
+                      type: {
+                        name:'RMSomething',
+                        reference:'RMSomething *'
+                      }
+                    })
+                  }
+                ],
+                returnType: {
+                  type:Maybe.Just({
+                    name:'instancetype',
+                    reference:'instancetype'
+                  }),
+                  modifiers:[ObjC.KeywordArgumentModifier.Nullable()]
+                }
+              }
+            ],
+            name:'RMSomeValue',
+            properties: [
+              {
+                comments:[],
+                modifiers:[ObjC.PropertyModifier.Nonatomic(), ObjC.PropertyModifier.Readonly()],
+                access: ObjC.PropertyAccess.Public(),
+                name:'value1',
+                returnType: {
+                  name:'RMSomething',
+                  reference:'RMSomething *'
+                }
+              },
+              {
+                comments:[],
+                modifiers:[ObjC.PropertyModifier.Nonatomic(), ObjC.PropertyModifier.Readonly()],
+                access: ObjC.PropertyAccess.Public(),
+                name:'value2',
+                returnType: {
+                  name:'RMSomething',
+                  reference:'RMSomething *'
+                }
+              }
+            ],
+            internalProperties:[],
+            implementedProtocols:[],
+            nullability: ObjC.ClassNullability.default
+          }
+        ],
+        structs: [],
+        namespaces: []
+      };
+
+      const renderedOutput:Maybe.Maybe<string> = ObjCRenderer.renderHeader(fileToRender);
+
+      const expectedOutput:Maybe.Maybe<string> = Maybe.Just<string>(
+        '@interface RMSomeValue : NSObject\n' +
+        '\n' +
+        '@property (nonatomic, readonly) RMSomething *value1;\n' +
+        '@property (nonatomic, readonly) RMSomething *value2;\n' +
+        '\n' +
+        '- (nullable instancetype)initWithValue1:(RMSomething *)value1 value2:(RMSomething *)value2;\n' +
+        '\n' +
+        '@end\n' +
+        '\n'
+      );
+
+      expect(renderedOutput).toEqualJSON(expectedOutput);
+    });
+
   });
 
   describe('#renderImplementation', function() {

--- a/src/__tests__/plugins/algebraic-type-function-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-function-matching-test.ts
@@ -107,7 +107,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
               nullability: ObjC.Nullability.Inherited()
             }
           ],
-          returnType: Maybe.Nothing<ObjC.Type>(),
+          returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
           isPublic: true,
           nullability: ObjC.ClassNullability.default
         },
@@ -124,7 +124,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
               nullability: ObjC.Nullability.Inherited()
             }
           ],
-          returnType: Maybe.Nothing<ObjC.Type>(),
+          returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
           isPublic: true,
           nullability: ObjC.ClassNullability.default
         }
@@ -240,7 +240,7 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
             })
           }
         ],
-        returnType: Maybe.Nothing<ObjC.Type>()
+        returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
       };
 
       expect(instanceMethods).toContain(expectedInstanceMethod);

--- a/src/__tests__/plugins/algebraic-type-initialization-test.ts
+++ b/src/__tests__/plugins/algebraic-type-initialization-test.ts
@@ -279,10 +279,10 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
               argument: Maybe.Nothing<ObjC.KeywordArgument>()
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'instancetype',
             reference: 'instancetype'
-          })
+          }), modifiers:[] }
         }
       ];
       expect(classMethods).toEqualJSON(expectedClassMethods);
@@ -389,10 +389,10 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
               })
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'instancetype',
             reference: 'instancetype'
-          })
+          }), modifiers:[] }
         },
         {
           belongsToProtocol:Maybe.Nothing<string>(),
@@ -417,10 +417,10 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
               })
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'instancetype',
             reference: 'instancetype'
-          })
+          }), modifiers:[] }
         }
       ];
       expect(classMethods).toEqualJSON(expectedClassMethods);

--- a/src/__tests__/plugins/builder-test.ts
+++ b/src/__tests__/plugins/builder-test.ts
@@ -84,10 +84,10 @@ describe('Plugins.Builder', function() {
                       argument:Maybe.Nothing<ObjC.KeywordArgument>()
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 },
                 {
                   belongsToProtocol:Maybe.Nothing<string>(),
@@ -109,10 +109,10 @@ describe('Plugins.Builder', function() {
                       })
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 }
               ],
               comments:[],
@@ -130,10 +130,10 @@ describe('Plugins.Builder', function() {
                       argument:Maybe.Nothing<ObjC.KeywordArgument>()
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'FooBarBaz',
                     reference: 'FooBarBaz *'
-                  })
+                  }), modifiers:[] }
                 }
               ],
               name:'FooBarBazBuilder',
@@ -214,10 +214,10 @@ describe('Plugins.Builder', function() {
                       argument:Maybe.Nothing<ObjC.KeywordArgument>()
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 },
                 {
                   belongsToProtocol:Maybe.Nothing<string>(),
@@ -239,10 +239,10 @@ describe('Plugins.Builder', function() {
                       })
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 }
               ],
               comments:[],
@@ -260,10 +260,10 @@ describe('Plugins.Builder', function() {
                       argument:Maybe.Nothing<ObjC.KeywordArgument>()
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'RMFerr',
                     reference: 'RMFerr *'
-                  })
+                  }), modifiers:[] }
                 }
               ],
               name:'RMFerrBuilder',
@@ -393,10 +393,10 @@ describe('Plugins.Builder', function() {
                       argument:Maybe.Nothing<ObjC.KeywordArgument>()
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 },
                 {
                   belongsToProtocol:Maybe.Nothing<string>(),
@@ -421,10 +421,10 @@ describe('Plugins.Builder', function() {
                       })
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 }
               ],
               comments:[],
@@ -442,10 +442,10 @@ describe('Plugins.Builder', function() {
                       argument:Maybe.Nothing<ObjC.KeywordArgument>()
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'RMFerr',
                     reference: 'RMFerr *'
-                  })
+                  }), modifiers:[] }
                 },
                 {
                   belongsToProtocol:Maybe.Nothing<string>(),
@@ -468,10 +468,10 @@ describe('Plugins.Builder', function() {
                       })
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 },
                 {
                   belongsToProtocol:Maybe.Nothing<string>(),
@@ -494,10 +494,10 @@ describe('Plugins.Builder', function() {
                       })
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 },
                 {
                   belongsToProtocol:Maybe.Nothing<string>(),
@@ -520,10 +520,10 @@ describe('Plugins.Builder', function() {
                       })
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 }
               ],
               name:'RMFerrBuilder',
@@ -684,10 +684,10 @@ describe('Plugins.Builder', function() {
                       argument:Maybe.Nothing<ObjC.KeywordArgument>()
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 },
                 {
                   belongsToProtocol:Maybe.Nothing<string>(),
@@ -712,10 +712,10 @@ describe('Plugins.Builder', function() {
                       })
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 }
               ],
               comments:[],
@@ -733,10 +733,10 @@ describe('Plugins.Builder', function() {
                       argument:Maybe.Nothing<ObjC.KeywordArgument>()
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'RMFerr',
                     reference: 'RMFerr *'
-                  })
+                  }), modifiers:[] }
                 },
                 {
                   belongsToProtocol:Maybe.Nothing<string>(),
@@ -759,10 +759,10 @@ describe('Plugins.Builder', function() {
                       })
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 },
                 {
                   belongsToProtocol:Maybe.Nothing<string>(),
@@ -785,10 +785,10 @@ describe('Plugins.Builder', function() {
                       })
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 },
                 {
                   belongsToProtocol:Maybe.Nothing<string>(),
@@ -811,10 +811,10 @@ describe('Plugins.Builder', function() {
                       })
                     }
                   ],
-                  returnType: Maybe.Just({
+                  returnType:{ type:Maybe.Just({
                     name:'instancetype',
                     reference: 'instancetype'
-                  })
+                  }), modifiers:[] }
                 }
               ],
               name:'RMFerrBuilder',

--- a/src/__tests__/plugins/coding-test.ts
+++ b/src/__tests__/plugins/coding-test.ts
@@ -265,10 +265,13 @@ describe('ObjectSpecPlugins.Coding', function() {
               })
             }
           ],
-          returnType:{ type:Maybe.Just<ObjC.Type>({
-            name: 'instancetype',
-            reference: 'instancetype'
-          }), modifiers:[] }
+          returnType: {
+            type:Maybe.Just<ObjC.Type>({
+              name: 'instancetype',
+              reference: 'instancetype'
+            }),
+            modifiers:[ObjC.KeywordArgumentModifier.Nullable()]
+          }
         },
         {
           belongsToProtocol:Maybe.Just<string>('NSCoding'),
@@ -798,10 +801,13 @@ describe('AlgebraicTypePlugins.Coding', function() {
               })
             }
           ],
-          returnType:{ type:Maybe.Just<ObjC.Type>({
-            name: 'instancetype',
-            reference: 'instancetype'
-          }), modifiers:[] }
+          returnType: {
+            type:Maybe.Just<ObjC.Type>({
+              name: 'instancetype',
+              reference: 'instancetype'
+            }),
+            modifiers:[ObjC.KeywordArgumentModifier.Nullable()]
+          }
         },
         {
           belongsToProtocol:Maybe.Just<string>('NSCoding'),

--- a/src/__tests__/plugins/coding-test.ts
+++ b/src/__tests__/plugins/coding-test.ts
@@ -265,10 +265,10 @@ describe('ObjectSpecPlugins.Coding', function() {
               })
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'instancetype',
             reference: 'instancetype'
-          })
+          }), modifiers:[] }
         },
         {
           belongsToProtocol:Maybe.Just<string>('NSCoding'),
@@ -292,7 +292,7 @@ describe('ObjectSpecPlugins.Coding', function() {
               })
             }
           ],
-          returnType: Maybe.Nothing<ObjC.Type>()
+          returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
         }
       ];
 
@@ -798,10 +798,10 @@ describe('AlgebraicTypePlugins.Coding', function() {
               })
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'instancetype',
             reference: 'instancetype'
-          })
+          }), modifiers:[] }
         },
         {
           belongsToProtocol:Maybe.Just<string>('NSCoding'),
@@ -835,7 +835,7 @@ describe('AlgebraicTypePlugins.Coding', function() {
               })
             }
           ],
-          returnType: Maybe.Nothing<ObjC.Type>()
+          returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
         }
       ];
 

--- a/src/__tests__/plugins/description-test.ts
+++ b/src/__tests__/plugins/description-test.ts
@@ -263,10 +263,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -316,10 +316,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -369,10 +369,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -422,10 +422,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -475,10 +475,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -528,10 +528,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -581,10 +581,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -634,10 +634,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -687,10 +687,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -740,10 +740,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -793,10 +793,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -846,10 +846,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -899,10 +899,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -953,10 +953,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -1006,10 +1006,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -1059,10 +1059,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -1112,10 +1112,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -1165,10 +1165,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -1218,10 +1218,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -1270,10 +1270,10 @@ describe('ObjectSpecPlugins.Description', function() {
                 argument: Maybe.Nothing<ObjC.KeywordArgument>()
               }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
         ];
 
@@ -1446,10 +1446,10 @@ describe('AlgebraicTypePlugins.Description', function() {
               argument: Maybe.Nothing<ObjC.KeywordArgument>()
             }
           ],
-          returnType: Maybe.Just({
+          returnType:{ type:Maybe.Just({
             name: 'NSString',
             reference: 'NSString *'
-          })
+          }), modifiers:[] }
         }
       ];
 

--- a/src/__tests__/plugins/equality-test.ts
+++ b/src/__tests__/plugins/equality-test.ts
@@ -441,10 +441,10 @@ describe('ObjectSpecPlugins.Equality', function() {
           ],
           comments: [],
           compilerAttributes:[],
-          returnType: Maybe.Just({
+          returnType:{ type:Maybe.Just({
             name: 'BOOL',
             reference: 'BOOL'
-          })
+          }), modifiers:[] }
         },
         {
           belongsToProtocol:Maybe.Just('NSObject'),
@@ -471,10 +471,10 @@ describe('ObjectSpecPlugins.Equality', function() {
           ],
           comments: [],
           compilerAttributes:[],
-          returnType: Maybe.Just({
+          returnType:{ type:Maybe.Just({
             name: 'NSUInteger',
             reference: 'NSUInteger'
-          })
+          }), modifiers:[] }
         }
       ];
 
@@ -553,10 +553,10 @@ describe('ObjectSpecPlugins.Equality', function() {
           ],
           comments: [],
           compilerAttributes:[],
-          returnType: Maybe.Just({
+          returnType:{ type:Maybe.Just({
             name: 'BOOL',
             reference: 'BOOL'
-          })
+          }), modifiers:[] }
         },
         {
           belongsToProtocol:Maybe.Just('NSObject'),
@@ -583,10 +583,10 @@ describe('ObjectSpecPlugins.Equality', function() {
           ],
           comments: [],
           compilerAttributes:[],
-          returnType: Maybe.Just({
+          returnType:{ type:Maybe.Just({
             name: 'NSUInteger',
             reference: 'NSUInteger'
-          })
+          }), modifiers:[] }
         }
       ];
 
@@ -680,10 +680,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'floatToCompare'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'BOOL',
             reference: 'BOOL'
-          }),
+          }), modifiers:[] },
           code: [
             'return fabsf(givenFloat - floatToCompare) < FLT_EPSILON * fabsf(givenFloat + floatToCompare) || fabsf(givenFloat - floatToCompare) < FLT_MIN;'
           ],
@@ -701,10 +701,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'givenFloat'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'NSUInteger',
             reference: 'NSUInteger'
-          }),
+          }), modifiers:[] },
           code: [
             'union {',
             '  float key;',
@@ -799,10 +799,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'floatToCompare'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'BOOL',
             reference: 'BOOL'
-          }),
+          }), modifiers:[] },
           code: [
             'return fabsf(givenFloat - floatToCompare) < FLT_EPSILON * fabsf(givenFloat + floatToCompare) || fabsf(givenFloat - floatToCompare) < FLT_MIN;'
           ],
@@ -820,10 +820,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'givenFloat'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'NSUInteger',
             reference: 'NSUInteger'
-          }),
+          }), modifiers:[] },
           code: [
             'union {',
             '  float key;',
@@ -904,10 +904,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'doubleToCompare'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'BOOL',
             reference: 'BOOL'
-          }),
+          }), modifiers:[] },
           code: [
             'return fabs(givenDouble - doubleToCompare) < DBL_EPSILON * fabs(givenDouble + doubleToCompare) || fabs(givenDouble - doubleToCompare) < DBL_MIN;'
           ],
@@ -925,10 +925,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'givenDouble'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'NSUInteger',
             reference: 'NSUInteger'
-          }),
+          }), modifiers:[] },
           code: [
             'union {',
             '  double key;',
@@ -1000,10 +1000,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'floatToCompare'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'BOOL',
             reference: 'BOOL'
-          }),
+          }), modifiers:[] },
           code: [
             'return fabsf(givenFloat - floatToCompare) < FLT_EPSILON * fabsf(givenFloat + floatToCompare) || fabsf(givenFloat - floatToCompare) < FLT_MIN;'
           ],
@@ -1028,10 +1028,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'doubleToCompare'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'BOOL',
             reference: 'BOOL'
-          }),
+          }), modifiers:[] },
           code: [
             'return fabs(givenDouble - doubleToCompare) < DBL_EPSILON * fabs(givenDouble + doubleToCompare) || fabs(givenDouble - doubleToCompare) < DBL_MIN;'
           ],
@@ -1056,10 +1056,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'cgFloatToCompare'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'BOOL',
             reference: 'BOOL'
-          }),
+          }), modifiers:[] },
           code: [
             '#if CGFLOAT_IS_DOUBLE',
             '  BOOL useDouble = YES;',
@@ -1086,10 +1086,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'givenFloat'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'NSUInteger',
             reference: 'NSUInteger'
-          }),
+          }), modifiers:[] },
           code: [
             'union {',
             '  float key;',
@@ -1129,10 +1129,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'givenDouble'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'NSUInteger',
             reference: 'NSUInteger'
-          }),
+          }), modifiers:[] },
           code: [
             'union {',
             '  double key;',
@@ -1162,10 +1162,10 @@ describe('ObjectSpecPlugins.Equality', function() {
               name: 'givenCGFloat'
             }
           ],
-          returnType: Maybe.Just<ObjC.Type>({
+          returnType:{ type:Maybe.Just<ObjC.Type>({
             name: 'NSUInteger',
             reference: 'NSUInteger'
-          }),
+          }), modifiers:[] },
           code: [
             '#if CGFLOAT_IS_DOUBLE',
             '  BOOL useDouble = YES;',

--- a/src/__tests__/plugins/immutable-properties-test.ts
+++ b/src/__tests__/plugins/immutable-properties-test.ts
@@ -93,10 +93,10 @@ describe('Plugins.ImmutableProperties', function() {
               })
             }
           ],
-          returnType: Maybe.Just({
+          returnType:{ type:Maybe.Just({
             name:'instancetype',
             reference: 'instancetype'
-          })
+          }), modifiers:[] }
         }
       ];
 
@@ -158,10 +158,10 @@ describe('Plugins.ImmutableProperties', function() {
               })
             }
           ],
-          returnType: Maybe.Just({
+          returnType:{ type:Maybe.Just({
             name:'instancetype',
             reference: 'instancetype'
-          })
+          }), modifiers:[] }
         }
       ];
 
@@ -301,10 +301,10 @@ describe('Plugins.ImmutableProperties', function() {
               })
             }
           ],
-          returnType: Maybe.Just({
+          returnType:{ type:Maybe.Just({
             name:'instancetype',
             reference: 'instancetype'
-          })
+          }), modifiers:[] }
         }
       ];
 
@@ -444,10 +444,10 @@ describe('Plugins.ImmutableProperties', function() {
               })
             }
           ],
-          returnType: Maybe.Just({
+          returnType:{ type:Maybe.Just({
             name:'instancetype',
             reference: 'instancetype'
-          })
+          }), modifiers:[] }
         }
       ];
 

--- a/src/__tests__/value-object-creation-test.ts
+++ b/src/__tests__/value-object-creation-test.ts
@@ -57,10 +57,10 @@ describe('ObjectSpecCreation', function() {
                   argument: Maybe.Nothing<ObjC.KeywordArgument>()
                 }
               ],
-              returnType: Maybe.Just({
+              returnType:{ type:Maybe.Just({
                 name: 'NSString',
                 reference: 'NSString *'
-              })
+              }), modifiers:[] }
             }
           ];
           return instanceMethods;
@@ -433,10 +433,10 @@ describe('ObjectSpecCreation', function() {
               argument: Maybe.Nothing<ObjC.KeywordArgument>()
             }
             ],
-            returnType: Maybe.Just({
+            returnType:{ type:Maybe.Just({
               name: 'NSString',
               reference: 'NSString *'
-            })
+            }), modifiers:[] }
           }
           ];
           return instanceMethods;
@@ -543,10 +543,10 @@ describe('ObjectSpecCreation', function() {
                   argument: Maybe.Nothing<ObjC.KeywordArgument>()
                 }
               ],
-              returnType: Maybe.Just({
+              returnType:{ type:Maybe.Just({
                 name: 'NSString',
                 reference: 'NSString *'
-              })
+              }), modifiers:[] }
             },
             {
               belongsToProtocol:Maybe.Nothing<string>(),
@@ -561,10 +561,10 @@ describe('ObjectSpecCreation', function() {
                   argument: Maybe.Nothing<ObjC.KeywordArgument>()
                 }
               ],
-              returnType: Maybe.Just({
+              returnType:{ type:Maybe.Just({
                 name: 'NSString',
                 reference: 'NSString *'
-              })
+              }), modifiers:[] }
             },
             {
               belongsToProtocol:Maybe.Nothing<string>(),
@@ -579,10 +579,10 @@ describe('ObjectSpecCreation', function() {
                   argument: Maybe.Nothing<ObjC.KeywordArgument>()
                 }
               ],
-              returnType: Maybe.Just({
+              returnType:{ type:Maybe.Just({
                 name: 'instancetype',
                 reference: 'instancetype'
-              })
+              }), modifiers:[] }
             }
           ];
           return instanceMethods;
@@ -932,10 +932,10 @@ describe('ObjectSpecCreation', function() {
                   argument: Maybe.Nothing<ObjC.KeywordArgument>()
                 }
               ],
-              returnType: Maybe.Just({
+              returnType:{ type:Maybe.Just({
                 name: 'NSString',
                 reference: 'NSString *'
-              })
+              }), modifiers:[] }
             },
             {
               belongsToProtocol:Maybe.Nothing<string>(),
@@ -950,10 +950,10 @@ describe('ObjectSpecCreation', function() {
                   argument: Maybe.Nothing<ObjC.KeywordArgument>()
                 }
               ],
-              returnType: Maybe.Just({
+              returnType:{ type:Maybe.Just({
                 name: 'NSString',
                 reference: 'NSString *'
-              })
+              }), modifiers:[] }
             }
           ];
           return instanceMethods;
@@ -1021,10 +1021,10 @@ describe('ObjectSpecCreation', function() {
                   argument: Maybe.Nothing<ObjC.KeywordArgument>()
                 }
               ],
-              returnType: Maybe.Just({
+              returnType:{ type:Maybe.Just({
                 name: 'instancetype',
                 reference: 'instancetype'
-              })
+              }), modifiers:[] }
             }
           ];
           return instanceMethods;
@@ -1167,10 +1167,10 @@ describe('ObjectSpecCreation', function() {
                   argument: Maybe.Nothing<ObjC.KeywordArgument>()
                 }
               ],
-              returnType: Maybe.Just({
+              returnType:{ type:Maybe.Just({
                 name: 'NSString',
                 reference: 'NSString *'
-              })
+              }), modifiers:[] }
             },
             {
               belongsToProtocol:Maybe.Nothing<string>(),
@@ -1185,10 +1185,10 @@ describe('ObjectSpecCreation', function() {
                   argument: Maybe.Nothing<ObjC.KeywordArgument>()
                 }
               ],
-              returnType: Maybe.Just({
+              returnType:{ type:Maybe.Just({
                 name: 'NSString',
                 reference: 'NSString *'
-              })
+              }), modifiers:[] }
             }
           ];
           return instanceMethods;
@@ -1260,10 +1260,10 @@ describe('ObjectSpecCreation', function() {
                   argument: Maybe.Nothing<ObjC.KeywordArgument>()
                 }
               ],
-              returnType: Maybe.Just({
+              returnType:{ type:Maybe.Just({
                 name: 'instancetype',
                 reference: 'instancetype'
-              })
+              }), modifiers:[] }
             }
           ];
           return instanceMethods;

--- a/src/algebraic-type-utils.ts
+++ b/src/algebraic-type-utils.ts
@@ -124,7 +124,10 @@ export function blockTypeForSubtype(algebraicType:AlgebraicType.Type, subtype:Al
     comments: [],
     name: blockTypeNameForSubtype(algebraicType, subtype),
     parameters: attributesFromSubtype(subtype).map(blockTypeParameterForSubtypeAttribute),
-    returnType: Maybe.Nothing<ObjC.Type>(),
+    returnType: {
+      type: Maybe.Nothing<ObjC.Type>(),
+      modifiers: []
+    },
     isPublic: true,
     nullability: algebraicType.includes.indexOf('RMAssumeNonnull') >= 0 ? ObjC.ClassNullability.assumeNonnull : ObjC.ClassNullability.default 
   };

--- a/src/objc-renderer.ts
+++ b/src/objc-renderer.ts
@@ -48,7 +48,8 @@ function libraryImport(file:string, library:string):string {
 }
 
 function returnTypeReference(modifiers:ObjC.KeywordArgumentModifier[], type:ObjC.Type):string {
-  return type.reference; // add modifiers
+  const modifiersString:string = modifiers.length > 0 ? modifiers.map(toKeywordArgumentModifierString).join(' ') + ' ' : '';
+  return modifiersString + type.reference;
 }
 
 function returnVoid():string {

--- a/src/objc-renderer.ts
+++ b/src/objc-renderer.ts
@@ -47,16 +47,16 @@ function libraryImport(file:string, library:string):string {
   return '#import <' + library + '/' + file + '>';
 }
 
-function returnTypeReference(type:ObjC.Type):string {
-  return type.reference;
+function returnTypeReference(modifiers:ObjC.KeywordArgumentModifier[], type:ObjC.Type):string {
+  return type.reference; // add modifiers
 }
 
 function returnVoid():string {
   return 'void';
 }
 
-function toTypeString(type:Maybe.Maybe<ObjC.Type>):string {
-  return Maybe.match(returnTypeReference, returnVoid, type);
+function toTypeString(returnType:ObjC.ReturnType):string {
+  return Maybe.match(FunctionUtils.pApplyf2(returnType.modifiers, returnTypeReference), returnVoid, returnType.type);
 }
 
 function toImportString(givenImport:ObjC.Import):string {
@@ -490,7 +490,7 @@ function returnVoidWithASpace():string {
   return returnVoid() + ' ';
 }
 
-function toFunctionReturnTypeString(returnType:Maybe.Maybe<ObjC.Type>):string {
+function toFunctionReturnTypeString(returnType:ObjC.ReturnType):string {
   return renderableTypeReferenceNestingSubsequentToken(toTypeString(returnType));
 }
 

--- a/src/objc.ts
+++ b/src/objc.ts
@@ -92,13 +92,18 @@ export interface Keyword {
   name:string;
 }
 
+export interface ReturnType {
+  type:Maybe.Maybe<Type>;
+  modifiers:KeywordArgumentModifier[];
+}
+
 export interface Method {
   belongsToProtocol:Maybe.Maybe<string>;
   code:string[];
   comments:Comment[];
   compilerAttributes:string[];
   keywords:Keyword[];
-  returnType:Maybe.Maybe<Type>;
+  returnType:ReturnType;
 }
 
 export interface FunctionParameter {
@@ -110,7 +115,7 @@ export interface Function {
   comments:Comment[];
   name:string;
   parameters:FunctionParameter[];
-  returnType:Maybe.Maybe<Type>;
+  returnType:ReturnType;
   code:string[];
   isPublic:boolean;
 }
@@ -125,7 +130,7 @@ export interface BlockType {
   comments:Comment[];
   name:string;
   parameters:BlockTypeParameter[];
-  returnType:Maybe.Maybe<Type>;
+  returnType:ReturnType;
   isPublic:boolean;
   nullability:ClassNullability;
 }

--- a/src/plugins/algebraic-type-function-matching.ts
+++ b/src/plugins/algebraic-type-function-matching.ts
@@ -42,7 +42,10 @@ function instanceMethodForMatchingSubtypesOfAlgebraicType(algebraicType:Algebrai
     comments: [],
     compilerAttributes:[],
     keywords: instanceMethodKeywordsForMatchingSubtypesOfAlgebraicType(algebraicType),
-    returnType: Maybe.Nothing<ObjC.Type>()
+    returnType: {
+      type: Maybe.Nothing<ObjC.Type>(),
+      modifiers: []
+    }
   };
 }
 

--- a/src/plugins/algebraic-type-initialization.ts
+++ b/src/plugins/algebraic-type-initialization.ts
@@ -104,10 +104,13 @@ function initializationClassMethodForSubtype(algebraicType:AlgebraicType.Type, s
     comments:[],
     compilerAttributes:[],
     keywords: keywordsForSubtype(subtype),
-    returnType: Maybe.Just<ObjC.Type>({
-      name: 'instancetype',
-      reference: 'instancetype'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'instancetype',
+        reference: 'instancetype'
+      }),
+      modifiers: []
+    }
   };
 }
 

--- a/src/plugins/builder.ts
+++ b/src/plugins/builder.ts
@@ -44,10 +44,13 @@ function builderClassMethodForValueType(objectType:ObjectSpec.Type):ObjC.Method 
         argument:Maybe.Nothing<ObjC.KeywordArgument>()
       }
     ],
-    returnType: Maybe.Just({
-      name:'instancetype',
-      reference:'instancetype'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'instancetype',
+        reference: 'instancetype'
+      }),
+      modifiers: []
+    }
   };
 }
 
@@ -109,10 +112,13 @@ function builderFromExistingObjectClassMethodForValueType(objectType:ObjectSpec.
         })
       }
     ],
-    returnType: Maybe.Just({
-      name:'instancetype',
-      reference:'instancetype'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'instancetype',
+        reference: 'instancetype'
+      }),
+      modifiers: []
+    }
   };
 }
 
@@ -134,10 +140,13 @@ function buildObjectInstanceMethodForValueType(objectType:ObjectSpec.Type):ObjC.
         argument:Maybe.Nothing<ObjC.KeywordArgument>()
       }
     ],
-    returnType: Maybe.Just({
-      name: objectType.typeName,
-      reference: ObjectSpecUtils.typeReferenceForValueTypeWithName(objectType.typeName)
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: objectType.typeName,
+        reference: ObjectSpecUtils.typeReferenceForValueTypeWithName(objectType.typeName)
+      }),
+      modifiers: []
+    }
   };
 }
 
@@ -180,10 +189,13 @@ function withInstanceMethodForAttribute(supportsValueSemantics:boolean, attribut
         })
       }
     ],
-    returnType: Maybe.Just({
-      name:'instancetype',
-      reference:'instancetype'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'instancetype',
+        reference: 'instancetype'
+      }),
+      modifiers: []
+    }
   };
 }
 

--- a/src/plugins/coding.ts
+++ b/src/plugins/coding.ts
@@ -106,10 +106,13 @@ function decodeMethodWithCode(code:string[]):ObjC.Method {
         })
       }
     ],
-    returnType: Maybe.Just<ObjC.Type>({
-      name: 'instancetype',
-      reference: 'instancetype'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'instancetype',
+        reference: 'instancetype'
+      }),
+      modifiers: []
+    }
   };
 }
 
@@ -132,7 +135,10 @@ function encodeMethodWithCode(code:string[]):ObjC.Method {
         })
       }
     ],
-    returnType: Maybe.Nothing<ObjC.Type>()
+    returnType: {
+      type: Maybe.Nothing<ObjC.Type>(),
+      modifiers: []
+    }
   };
 }
 

--- a/src/plugins/coding.ts
+++ b/src/plugins/coding.ts
@@ -111,7 +111,7 @@ function decodeMethodWithCode(code:string[]):ObjC.Method {
         name: 'instancetype',
         reference: 'instancetype'
       }),
-      modifiers: []
+      modifiers: [ObjC.KeywordArgumentModifier.Nullable()]
     }
   };
 }

--- a/src/plugins/copying.ts
+++ b/src/plugins/copying.ts
@@ -34,10 +34,13 @@ function copyInstanceMethod():ObjC.Method {
         })
       }
     ],
-    returnType: Maybe.Just<ObjC.Type>({
-      name: 'id',
-      reference: 'id'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'id',
+        reference: 'id'
+      }),
+      modifiers: []
+    }
   };
 }
 

--- a/src/plugins/description.ts
+++ b/src/plugins/description.ts
@@ -260,10 +260,13 @@ function descriptionInstanceMethodWithCode(code:string[]):ObjC.Method {
         argument: Maybe.Nothing<ObjC.KeywordArgument>()
       }
     ],
-    returnType: Maybe.Just({
-      name: 'NSString',
-      reference: 'NSString *'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'NSString',
+        reference: 'NSString *'
+      }),
+      modifiers: []
+    }
   };
 }
 

--- a/src/plugins/equality.ts
+++ b/src/plugins/equality.ts
@@ -635,10 +635,13 @@ function isEqualInstanceMethod(typeName:string, generatedTypeEqualityInformation
     code: code,
     comments:[],
     compilerAttributes:[],
-    returnType: Maybe.Just({
-      name: 'BOOL',
-      reference: 'BOOL'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'BOOL',
+        reference: 'BOOL'
+      }),
+      modifiers: []
+    }
   };
 }
 
@@ -676,10 +679,13 @@ function hashInstanceMethod(generatedTypeEqualityInformation:GeneratedTypeEquali
     ],
     comments:[],
     compilerAttributes:[],
-    returnType: Maybe.Just({
-      name: 'NSUInteger',
-      reference: 'NSUInteger'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'NSUInteger',
+        reference: 'NSUInteger'
+      }),
+      modifiers: []
+    }
   };
 }
 
@@ -702,10 +708,13 @@ const COMPARE_FLOATS_FN:ObjC.Function = {
       name: 'floatToCompare'
     }
   ],
-  returnType: Maybe.Just<ObjC.Type>({
-    name: 'BOOL',
-    reference: 'BOOL'
-  }),
+  returnType: {
+    type: Maybe.Just<ObjC.Type>({
+      name: 'BOOL',
+      reference: 'BOOL'
+    }),
+    modifiers: []
+  },
   code: [
     'return fabsf(givenFloat - floatToCompare) < FLT_EPSILON * fabsf(givenFloat + floatToCompare) || fabsf(givenFloat - floatToCompare) < FLT_MIN;'
   ],
@@ -724,10 +733,13 @@ const HASH_FLOAT_FN:ObjC.Function = {
       name: 'givenFloat'
     }
   ],
-  returnType: Maybe.Just<ObjC.Type>({
-    name: 'NSUInteger',
-    reference: 'NSUInteger'
-  }),
+  returnType: {
+    type: Maybe.Just<ObjC.Type>({
+      name: 'NSUInteger',
+      reference: 'NSUInteger'
+    }),
+    modifiers: []
+  },
   code: [
     'union {',
     '  float key;',
@@ -775,10 +787,13 @@ const COMPARE_DOUBLES_FN:ObjC.Function = {
       name: 'doubleToCompare'
     }
   ],
-  returnType: Maybe.Just<ObjC.Type>({
-    name: 'BOOL',
-    reference: 'BOOL'
-  }),
+  returnType: {
+    type: Maybe.Just<ObjC.Type>({
+      name: 'BOOL',
+      reference: 'BOOL'
+    }),
+    modifiers: []
+  },
   code: [
     'return fabs(givenDouble - doubleToCompare) < DBL_EPSILON * fabs(givenDouble + doubleToCompare) || fabs(givenDouble - doubleToCompare) < DBL_MIN;'
   ],
@@ -797,10 +812,13 @@ const HASH_DOUBLE_FN:ObjC.Function = {
       name: 'givenDouble'
     }
   ],
-  returnType: Maybe.Just<ObjC.Type>({
-    name: 'NSUInteger',
-    reference: 'NSUInteger'
-  }),
+  returnType: {
+    type: Maybe.Just<ObjC.Type>({
+      name: 'NSUInteger',
+      reference: 'NSUInteger'
+    }),
+    modifiers: []
+  },
   code: [
     'union {',
     '  double key;',
@@ -853,10 +871,13 @@ const COMPARE_CGFLOATS_FN:ObjC.Function = {
       name: 'cgFloatToCompare'
     }
   ],
-  returnType: Maybe.Just<ObjC.Type>({
-    name: 'BOOL',
-    reference: 'BOOL'
-  }),
+  returnType: {
+    type: Maybe.Just<ObjC.Type>({
+      name: 'BOOL',
+      reference: 'BOOL'
+    }),
+    modifiers: []
+  },
   code: wrapCGFloatTypeComparisonCodeToAvoidUnusedFunctionWarning(
     'return CompareDoubles(givenCGFloat, cgFloatToCompare);',
     'return CompareFloats(givenCGFloat, cgFloatToCompare);'
@@ -876,10 +897,13 @@ const HASH_CGFLOATS_FN:ObjC.Function = {
       name: 'givenCGFloat'
     }
   ],
-  returnType: Maybe.Just<ObjC.Type>({
-    name: 'NSUInteger',
-    reference: 'NSUInteger'
-  }),
+  returnType: {
+    type: Maybe.Just<ObjC.Type>({
+      name: 'NSUInteger',
+      reference: 'NSUInteger'
+    }),
+    modifiers: []
+  },
   code: wrapCGFloatTypeComparisonCodeToAvoidUnusedFunctionWarning(
     'return HashDouble(givenCGFloat);',
     'return HashFloat(givenCGFloat);'

--- a/src/plugins/immutable-properties.ts
+++ b/src/plugins/immutable-properties.ts
@@ -79,10 +79,13 @@ function initializerFromAttributes(supportsValueSemantics:boolean, attributes:Ob
     comments:[],
     compilerAttributes:["NS_DESIGNATED_INITIALIZER"],
     keywords: keywords,
-    returnType: Maybe.Just({
-      name: 'instancetype',
-      reference: 'instancetype'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'instancetype',
+        reference: 'instancetype'
+      }),
+      modifiers: []
+    }
   };
 }
 

--- a/src/plugins/init-new-unavailable.ts
+++ b/src/plugins/init-new-unavailable.ts
@@ -31,10 +31,13 @@ function initUnavailableInstanceMethod():ObjC.Method {
         argument: Maybe.Nothing<ObjC.KeywordArgument>()
       }
     ],
-    returnType: Maybe.Just({
-      name: 'instancetype',
-      reference: 'instancetype'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'instancetype',
+        reference: 'instancetype'
+      }),
+      modifiers: []
+    }
   };
 }
 
@@ -50,10 +53,13 @@ function newUnavailableClassMethod():ObjC.Method {
         argument: Maybe.Nothing<ObjC.KeywordArgument>()
       }
     ],
-    returnType: Maybe.Just({
-      name: 'instancetype',
-      reference: 'instancetype'
-    })
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'instancetype',
+        reference: 'instancetype'
+      }),
+      modifiers: []
+    }
   };
 }
 


### PR DESCRIPTION
This is needed, since you currently can't use the `RMCoding` plugin together with `RMAssumeNonnull`, because we will create the wrong nullability signature for `initWithCoder` in this case, which returns a nullable value.

- Introducing a new `ObjC.ReturnType` type
- Added new unit test for ObjC Renderer
- Updated unit (I used some regex replacing here.. thus the test formatting isn't ideal in all places, but I think that's acceptable?)
- Utilizing it for the `RMCoding` plugin by making the `initWithCoder` return type explicitly nullable
- Updated Coding Acceptance tests