### PR TITLE
Add internal-only initializer for ADTs

### DIFF
--- a/features/algebraic-type-forward-declaration.feature
+++ b/features/algebraic-type-forward-declaration.feature
@@ -73,7 +73,7 @@ Feature: Outputting forward declarations in Algebraic Types
 
       + (instancetype)firstSubtypeWithFirstValue:(RMProxy *)firstValue secondValue:(NSUInteger)secondValue
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesFirstSubtype;
         object->_firstSubtype_firstValue = firstValue;
         object->_firstSubtype_secondValue = secondValue;
@@ -82,7 +82,7 @@ Feature: Outputting forward declarations in Algebraic Types
 
       + (instancetype)secondSubtypeWithSomething:(BOOL)something
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSecondSubtype;
         object->_secondSubtype_something = something;
         return object;
@@ -90,7 +90,7 @@ Feature: Outputting forward declarations in Algebraic Types
 
       + (instancetype)someRandomSubtype
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSomeRandomSubtype;
         return object;
       }
@@ -133,6 +133,11 @@ Feature: Outputting forward declarations in Algebraic Types
           result = base;
         }
         return result;
+      }
+
+      - (instancetype)internalInit
+      {
+        return [super init];
       }
 
       - (BOOL)isEqual:(SimpleADT *)object

--- a/features/algebraic-types-coding.feature
+++ b/features/algebraic-types-coding.feature
@@ -69,7 +69,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)firstSubtypeWithFirstValue:(NSString *)firstValue secondValue:(NSUInteger)secondValue
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesFirstSubtype;
         object->_firstSubtype_firstValue = firstValue;
         object->_firstSubtype_secondValue = secondValue;
@@ -78,7 +78,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)secondSubtypeWithSomething:(BOOL)something
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSecondSubtype;
         object->_secondSubtype_something = something;
         return object;
@@ -155,6 +155,11 @@ Feature: Outputting Algebraic Types
           result = base;
         }
         return result;
+      }
+
+      - (instancetype)internalInit
+      {
+        return [super init];
       }
 
       - (BOOL)isEqual:(SimpleADT *)object

--- a/features/algebraic-types-cplusplus.feature
+++ b/features/algebraic-types-cplusplus.feature
@@ -69,7 +69,7 @@ Feature: Outputting ObjC++ Algebraic Types
 
       + (instancetype)firstSubtypeWithFirstValue:(NSString *)firstValue secondValue:(NSUInteger)secondValue
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesFirstSubtype;
         object->_firstSubtype_firstValue = firstValue;
         object->_firstSubtype_secondValue = secondValue;
@@ -78,7 +78,7 @@ Feature: Outputting ObjC++ Algebraic Types
 
       + (instancetype)secondSubtypeWithSomething:(BOOL)something
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSecondSubtype;
         object->_secondSubtype_something = something;
         return object;
@@ -86,7 +86,7 @@ Feature: Outputting ObjC++ Algebraic Types
 
       + (instancetype)someRandomSubtype
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSomeRandomSubtype;
         return object;
       }
@@ -129,6 +129,11 @@ Feature: Outputting ObjC++ Algebraic Types
           result = base;
         }
         return result;
+      }
+
+      - (instancetype)internalInit
+      {
+        return [super init];
       }
 
       - (BOOL)isEqual:(SimpleADT *)object

--- a/features/algebraic-types.feature
+++ b/features/algebraic-types.feature
@@ -83,7 +83,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)firstSubtypeWithFirstValue:(NSString *)firstValue secondValue:(NSUInteger)secondValue
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesFirstSubtype;
         object->_firstSubtype_firstValue = firstValue;
         object->_firstSubtype_secondValue = secondValue;
@@ -92,7 +92,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)secondSubtypeWithSomething:(BOOL)something
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSecondSubtype;
         object->_secondSubtype_something = something;
         return object;
@@ -100,7 +100,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)someAttributeSubtype:(NSUInteger)someAttributeSubtype
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSomeAttributeSubtype;
         object->_someAttributeSubtype = someAttributeSubtype;
         return object;
@@ -108,7 +108,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)someRandomSubtype
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSomeRandomSubtype;
         return object;
       }
@@ -155,6 +155,11 @@ Feature: Outputting Algebraic Types
           result = base;
         }
         return result;
+      }
+
+      - (instancetype)internalInit
+      {
+        return [super init];
       }
 
       - (BOOL)isEqual:(SimpleADT *)object
@@ -266,7 +271,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)firstSubtypeWithFirstValue:(NSString *)firstValue secondValue:(NSUInteger)secondValue
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesFirstSubtype;
         object->_firstSubtype_firstValue = firstValue;
         object->_firstSubtype_secondValue = secondValue;
@@ -275,7 +280,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)secondSubtypeWithSomething:(BOOL)something
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSecondSubtype;
         object->_secondSubtype_something = something;
         return object;
@@ -315,6 +320,11 @@ Feature: Outputting Algebraic Types
           result = base;
         }
         return result;
+      }
+
+      - (instancetype)internalInit
+      {
+        return [super init];
       }
 
       - (BOOL)isEqual:(SimpleADT *)object
@@ -421,7 +431,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)firstSubtypeWithFirstValue:(Foo *)firstValue secondValue:(NSUInteger)secondValue
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesFirstSubtype;
         object->_firstSubtype_firstValue = firstValue;
         object->_firstSubtype_secondValue = secondValue;
@@ -430,7 +440,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)secondSubtypeWithSomething:(BOOL)something
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSecondSubtype;
         object->_secondSubtype_something = something;
         return object;
@@ -438,7 +448,7 @@ Feature: Outputting Algebraic Types
 
       + (instancetype)someRandomSubtype
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSomeRandomSubtype;
         return object;
       }
@@ -481,6 +491,11 @@ Feature: Outputting Algebraic Types
           result = base;
         }
         return result;
+      }
+
+      - (instancetype)internalInit
+      {
+        return [super init];
       }
 
       - (BOOL)isEqual:(SimpleADT *)object

--- a/features/assume-nonnull.feature
+++ b/features/assume-nonnull.feature
@@ -163,14 +163,14 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
 
       + (instancetype)bar
       {
-        RMFoo *object = [[RMFoo alloc] init];
+        RMFoo *object = [[RMFoo alloc] internalInit];
         object->_subtype = _RMFooSubtypesBar;
         return object;
       }
 
       + (instancetype)bazWithAString:(NSString *)aString bString:(nullable NSString *)bString
       {
-        RMFoo *object = [[RMFoo alloc] init];
+        RMFoo *object = [[RMFoo alloc] internalInit];
         object->_subtype = _RMFooSubtypesBaz;
         object->_baz_aString = aString;
         object->_baz_bString = bString;
@@ -211,6 +211,11 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
           result = base;
         }
         return result;
+      }
+
+      - (instancetype)internalInit
+      {
+        return [super init];
       }
 
       - (BOOL)isEqual:(RMFoo *)object

--- a/features/generics.feature
+++ b/features/generics.feature
@@ -147,7 +147,7 @@ Feature: Outputting Objects With Generic Types
 
       + (instancetype)firstSubtypeWithNamesToAges:(NSDictionary<NSString *, NSNumber *> *)namesToAges
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesFirstSubtype;
         object->_firstSubtype_namesToAges = namesToAges;
         return object;
@@ -155,7 +155,7 @@ Feature: Outputting Objects With Generic Types
 
       + (instancetype)someAttributeSubtype:(NSDictionary<NSString *, NSString *> *)someAttributeSubtype
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSomeAttributeSubtype;
         object->_someAttributeSubtype = someAttributeSubtype;
         return object;
@@ -195,6 +195,11 @@ Feature: Outputting Objects With Generic Types
           result = base;
         }
         return result;
+      }
+
+      - (instancetype)internalInit
+      {
+        return [super init];
       }
 
       - (BOOL)isEqual:(SimpleADT *)object

--- a/features/nullability.feature
+++ b/features/nullability.feature
@@ -170,7 +170,7 @@ Feature: Outputting Objects With Nullability Annotations
 
       + (instancetype)firstSubtypeWithFirstValue:(nonnull NSString *)firstValue secondValue:(NSUInteger)secondValue
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesFirstSubtype;
         object->_firstSubtype_firstValue = firstValue;
         object->_firstSubtype_secondValue = secondValue;
@@ -179,7 +179,7 @@ Feature: Outputting Objects With Nullability Annotations
 
       + (instancetype)secondSubtypeWithSomething:(BOOL)something
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSecondSubtype;
         object->_secondSubtype_something = something;
         return object;
@@ -187,7 +187,7 @@ Feature: Outputting Objects With Nullability Annotations
 
       + (instancetype)someAttributeSubtype:(nullable NSNumber *)someAttributeSubtype
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSomeAttributeSubtype;
         object->_someAttributeSubtype = someAttributeSubtype;
         return object;
@@ -195,7 +195,7 @@ Feature: Outputting Objects With Nullability Annotations
 
       + (instancetype)someRandomSubtype
       {
-        SimpleADT *object = [[SimpleADT alloc] init];
+        SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesSomeRandomSubtype;
         return object;
       }
@@ -242,6 +242,11 @@ Feature: Outputting Objects With Nullability Annotations
           result = base;
         }
         return result;
+      }
+
+      - (instancetype)internalInit
+      {
+        return [super init];
       }
 
       - (BOOL)isEqual:(SimpleADT *)object

--- a/src/__tests__/plugins/algebraic-type-initialization-test.ts
+++ b/src/__tests__/plugins/algebraic-type-initialization-test.ts
@@ -241,6 +241,51 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
     });
   });
 
+  describe('#instanceMethods', function() {
+    it('returns an internal initializer', function() {
+      const algebraicType:AlgebraicType.Type = {
+        annotations: {},
+        name: 'Foo',
+        includes: [],
+        excludes: [],
+        typeLookups:[],
+        libraryName: Maybe.Nothing<string>(),
+        comments: [],
+        subtypes: [
+          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
+          {
+            name: 'SomeSubtype',
+            comments: [],
+            attributes: []
+          })
+        ]
+      };
+
+      const instanceMethods:ObjC.Method[] = AlgebraicTypePlugin.instanceMethods(algebraicType);
+      const expectedInstanceMethods:ObjC.Method[] = [
+        {
+          belongsToProtocol:Maybe.Just<string>('ADTInit'),
+          code: [
+            'return [super init];'
+          ],
+          comments: [],
+          compilerAttributes:[],
+          keywords: [
+            {
+              name: 'internalInit',
+              argument: Maybe.Nothing<ObjC.KeywordArgument>()
+            }
+          ],
+          returnType:{ type:Maybe.Just<ObjC.Type>({
+            name: 'instancetype',
+            reference: 'instancetype'
+          }), modifiers:[] }
+        }
+      ];
+      expect(instanceMethods).toEqualJSON(expectedInstanceMethods);
+    });
+  });
+
   describe('#classMethods', function() {
     it('returns a single class method when there is one subtype ' +
        'with no attributes', function() {
@@ -267,7 +312,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
         {
           belongsToProtocol:Maybe.Nothing<string>(),
           code: [
-            'Foo *object = [[Foo alloc] init];',
+            'Foo *object = [[Foo alloc] internalInit];',
             'object->_subtype = _FooSubtypesSomeSubtype;',
             'return object;'
           ],
@@ -357,7 +402,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
         {
           belongsToProtocol:Maybe.Nothing<string>(),
           code: [
-            'Test *object = [[Test alloc] init];',
+            'Test *object = [[Test alloc] internalInit];',
             'object->_subtype = _TestSubtypesSomeSubtype;',
             'object->_someSubtype_someString = someString;',
             'object->_someSubtype_someUnsignedInteger = someUnsignedInteger;',
@@ -397,7 +442,7 @@ describe('AlgebraicTypePlugins.AlgebraicTypeInitialization', function() {
         {
           belongsToProtocol:Maybe.Nothing<string>(),
           code: [
-            'Test *object = [[Test alloc] init];',
+            'Test *object = [[Test alloc] internalInit];',
             'object->_subtype = _TestSubtypesSingleAttributeSubtype;',
             'object->_singleAttributeSubtype = singleAttributeSubtype;',
             'return object;'

--- a/src/objc-renderer.ts
+++ b/src/objc-renderer.ts
@@ -207,10 +207,8 @@ function protocolsString(protocols:ObjC.Protocol[]):string {
   }
 }
 
-function implementedProtocolsIncludingNSObject(implementedProtocols:ObjC.Protocol[]):ObjC.Protocol[] {
-  return implementedProtocols.concat({
-    name: 'NSObject'
-  });
+function implementedProtocolsIncludingNSObjectAndADTInit(implementedProtocols:ObjC.Protocol[]):ObjC.Protocol[] {
+  return implementedProtocols.concat({ name: 'NSObject' }).concat({ name: 'ADTInit' });
 }
 
 const HEADER_FUNCTIONS_SECTION_BEGIN:string = '#ifdef __cplusplus\nextern "C" {\n#endif\n\n';
@@ -412,7 +410,7 @@ function headerClassSection(classInfo:ObjC.Class):string {
   const classMethodsStr = classInfo.classMethods.map(toClassMethodHeaderString).join('\n\n');
   const classMethodsSection = codeSectionForCodeString(classMethodsStr);
 
-  const instanceMethodsStr = classInfo.instanceMethods.filter(FunctionUtils.pApplyf2(implementedProtocolsIncludingNSObject(classInfo.implementedProtocols), includeMethodInHeader))
+  const instanceMethodsStr = classInfo.instanceMethods.filter(FunctionUtils.pApplyf2(implementedProtocolsIncludingNSObjectAndADTInit(classInfo.implementedProtocols), includeMethodInHeader))
                                                     .map(toInstanceMethodHeaderString).join('\n\n');
   const instanceMethodsSection = codeSectionForCodeString(instanceMethodsStr);
 

--- a/src/plugins/algebraic-type-initialization.ts
+++ b/src/plugins/algebraic-type-initialization.ts
@@ -91,9 +91,29 @@ function keywordsForSubtype(subtype:AlgebraicType.Subtype):ObjC.Keyword[] {
     });
 }
 
+function internalInitInstanceMethod() {
+  return {
+    belongsToProtocol:Maybe.Just<string>('ADTInit'),
+    code: ['return [super init];'],
+    comments:[],
+    compilerAttributes:[],
+    keywords: [{
+      argument: Maybe.Nothing<ObjC.KeywordArgument>(),
+      name: 'internalInit'
+    }],
+    returnType: {
+      type: Maybe.Just<ObjC.Type>({
+        name: 'instancetype',
+        reference: 'instancetype'
+      }),
+      modifiers: []
+    }
+  }; 
+}
+
 function initializationClassMethodForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype):ObjC.Method {
   const openingCode:string[] = [
-    algebraicType.name + ' *' + nameOfObjectWithinInitializer() + ' = [[' + algebraicType.name + ' alloc] init];',
+    algebraicType.name + ' *' + nameOfObjectWithinInitializer() + ' = [[' + algebraicType.name + ' alloc] internalInit];',
     nameOfObjectWithinInitializer() + '->' + AlgebraicTypeUtils.valueAccessorForInternalPropertyStoringSubtype() + ' = ' + AlgebraicTypeUtils.EnumerationValueNameForSubtype(algebraicType, subtype) + ';'
   ];
   const setterStatements:string[] = AlgebraicTypeUtils.attributesFromSubtype(subtype).map(FunctionUtils.pApplyf2(subtype, internalValueSettingCodeForAttribute));
@@ -282,7 +302,7 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
       return baseImports.concat(typeLookupImports).concat(attributeImports);
     },
     instanceMethods: function(algebraicType:AlgebraicType.Type):ObjC.Method[] {
-      return [];
+      return [internalInitInstanceMethod()];
     },
     internalProperties: function(algebraicType:AlgebraicType.Type):ObjC.Property[] {
       return internalPropertiesForImplementationOfAlgebraicType(algebraicType);


### PR DESCRIPTION
Now that we default ADT's to use init-new-unavailable, we can't call init internally either. Thus let's add an internal-only initializer.