### PR TITLE
Add forward protocol declaration to Builder Plugin

### DIFF
--- a/features/builders.feature
+++ b/features/builders.feature
@@ -16,6 +16,8 @@ Feature: Outputting Value Objects
         RMEnum(NSUInteger) someEnumValue
         %import library=RMCustomLibrary
         RMLibType* customLibObject
+        %import library=RMCustomProtocol
+        id<RMCustomProtocol> someObject
       }
       """
     And a file named "project/.valueObjectConfig" with:
@@ -34,6 +36,7 @@ Feature: Outputting Value Objects
       @class RMFooObject;
       @class RMRating;
       @class RMLibType;
+      @protocol RMCustomProtocol;
 
       @interface RMPageBuilder : NSObject
 
@@ -55,6 +58,8 @@ Feature: Outputting Value Objects
 
       - (instancetype)withCustomLibObject:(RMLibType *)customLibObject;
 
+      - (instancetype)withSomeObject:(id<RMCustomProtocol>)someObject;
+
       @end
 
       """
@@ -73,6 +78,7 @@ Feature: Outputting Value Objects
         RMRating *_rating;
         RMEnum _someEnumValue;
         RMLibType *_customLibObject;
+        id<RMCustomProtocol> _someObject;
       }
 
       + (instancetype)page
@@ -82,18 +88,19 @@ Feature: Outputting Value Objects
 
       + (instancetype)pageFromExistingPage:(RMPage *)existingPage
       {
-        return [[[[[[[RMPageBuilder page]
-                     withDoesUserLike:existingPage.doesUserLike]
-                    withIdentifier:existingPage.identifier]
-                   withLikeCount:existingPage.likeCount]
-                  withRating:existingPage.rating]
-                 withSomeEnumValue:existingPage.someEnumValue]
-                withCustomLibObject:existingPage.customLibObject];
+        return [[[[[[[[RMPageBuilder page]
+                      withDoesUserLike:existingPage.doesUserLike]
+                     withIdentifier:existingPage.identifier]
+                    withLikeCount:existingPage.likeCount]
+                   withRating:existingPage.rating]
+                  withSomeEnumValue:existingPage.someEnumValue]
+                 withCustomLibObject:existingPage.customLibObject]
+                withSomeObject:existingPage.someObject];
       }
 
       - (RMPage *)build
       {
-        return [[RMPage alloc] initWithDoesUserLike:_doesUserLike identifier:_identifier likeCount:_likeCount rating:_rating someEnumValue:_someEnumValue customLibObject:_customLibObject];
+        return [[RMPage alloc] initWithDoesUserLike:_doesUserLike identifier:_identifier likeCount:_likeCount rating:_rating someEnumValue:_someEnumValue customLibObject:_customLibObject someObject:_someObject];
       }
 
       - (instancetype)withDoesUserLike:(BOOL)doesUserLike
@@ -131,6 +138,12 @@ Feature: Outputting Value Objects
         _customLibObject = [customLibObject copy];
         return self;
       }
+
+			- (instancetype)withSomeObject:(id<RMCustomProtocol>)someObject
+			{
+        _someObject = [someObject copy];
+        return self;
+			}
 
       @end
 

--- a/src/objc-import-utils.ts
+++ b/src/objc-import-utils.ts
@@ -182,6 +182,26 @@ export function canForwardDeclareTypeForAttributeConsideringType(attribute:Objec
   return canForwardDeclareType(type);
 }
 
+export function shouldForwardProtocolDeclareAttribute(attribute:ObjectSpec.Attribute):boolean {
+  return Maybe.match(
+    function (protocol) {
+      return true;
+    },
+    function () {
+      return false;
+    }, attribute.type.conformingProtocol);
+}
+
+export function forwardProtocolDeclarationForAttribute(attribute:ObjectSpec.Attribute): ObjC.ForwardDeclaration {
+  return Maybe.match(
+    function (protocol) {
+      return ObjC.ForwardDeclaration.ForwardProtocolDeclaration(protocol);
+    },
+    function () {
+      return undefined;
+    }, attribute.type.conformingProtocol);
+}
+
 export function requiresPublicImportForType(typeName:string, computedType:ObjC.Type):boolean {
   return isImportRequiredForTypeWithName(typeName) && !canForwardDeclareType(computedType);
 }

--- a/src/plugins/builder.ts
+++ b/src/plugins/builder.ts
@@ -267,13 +267,16 @@ function forwardDeclarationsForBuilder(objectType:ObjectSpec.Type):ObjC.ForwardD
                                                                                        return ObjC.ForwardDeclaration.ForwardClassDeclaration(typeLookup.name);
                                                                                      });
 
-  const attributeDeclarations:ObjC.ForwardDeclaration[] = objectType.attributes.filter(ObjCImportUtils.canForwardDeclareTypeForAttribute).map(function(attribute:ObjectSpec.Attribute):ObjC.ForwardDeclaration {
+  const attributeForwardClassDeclarations:ObjC.ForwardDeclaration[] = objectType.attributes.filter(ObjCImportUtils.canForwardDeclareTypeForAttribute).map(function(attribute:ObjectSpec.Attribute):ObjC.ForwardDeclaration {
     return ObjC.ForwardDeclaration.ForwardClassDeclaration(attribute.type.name);
   });
 
+  const attributeForwardProtocolDeclarations:ObjC.ForwardDeclaration[] =  objectType.attributes.filter(ObjCImportUtils.shouldForwardProtocolDeclareAttribute)
+                                                                                               .map(ObjCImportUtils.forwardProtocolDeclarationForAttribute);
+
   return [
     ObjC.ForwardDeclaration.ForwardClassDeclaration(objectType.typeName)
-  ].concat(typeLookupForwardDeclarations).concat(attributeDeclarations);
+  ].concat(typeLookupForwardDeclarations).concat(attributeForwardClassDeclarations).concat(attributeForwardProtocolDeclarations);
 }
 
 function builderFileForValueType(objectType:ObjectSpec.Type):Code.File {

--- a/src/plugins/immutable-properties.ts
+++ b/src/plugins/immutable-properties.ts
@@ -207,28 +207,8 @@ function shouldForwardClassDeclareAttribute(valueTypeName:string, makePublicImpo
   return declaringPublicAttributes || attributeTypeReferencesObjectType;
 }
 
-function shouldForwardProtocolDeclareAttribute(attribute:ObjectSpec.Attribute):boolean {
-  return Maybe.match(
-    function (protocol) {
-      return true;
-    },
-    function () {
-      return false;
-    }, attribute.type.conformingProtocol);
-}
-
 function forwardClassDeclarationForAttribute(attribute:ObjectSpec.Attribute): ObjC.ForwardDeclaration {
   return ObjC.ForwardDeclaration.ForwardClassDeclaration(attribute.type.name);
-}
-
-function forwardProtocolDeclarationForAttribute(attribute:ObjectSpec.Attribute): ObjC.ForwardDeclaration {
-  return Maybe.match(
-    function (protocol) {
-      return ObjC.ForwardDeclaration.ForwardProtocolDeclaration(protocol);
-    },
-    function () {
-      return undefined;
-    }, attribute.type.conformingProtocol);
 }
 
 export function createPlugin():ObjectSpec.Plugin {
@@ -259,7 +239,7 @@ export function createPlugin():ObjectSpec.Plugin {
                                                                      .map(forwardClassDeclarationForAttribute);
       const attributeForwardProtocolDeclarations = makePublicImports
         ? []
-        : objectType.attributes.filter(shouldForwardProtocolDeclareAttribute).map(forwardProtocolDeclarationForAttribute);
+        : objectType.attributes.filter(ObjCImportUtils.shouldForwardProtocolDeclareAttribute).map(ObjCImportUtils.forwardProtocolDeclarationForAttribute);
       return [].concat(typeLookupForwardDeclarations).concat(attributeForwardClassDeclarations).concat(attributeForwardProtocolDeclarations);
     },
     functions: function(objectType:ObjectSpec.Type):ObjC.Function[] {


### PR DESCRIPTION
Similar to https://github.com/facebook/remodel/pull/47, add forward protocol declaration to the builder plugin as well.

Tested by generating a file, running all acceptance and unit tests.