### PR TITLE
Undo adding copy semantic for id<protocol>

### DIFF
--- a/features/builders.feature
+++ b/features/builders.feature
@@ -141,7 +141,7 @@ Feature: Outputting Value Objects
 
 			- (instancetype)withSomeObject:(id<RMCustomProtocol>)someObject
 			{
-        _someObject = [someObject copy];
+        _someObject = someObject;
         return self;
 			}
 

--- a/features/forward-declaration.feature
+++ b/features/forward-declaration.feature
@@ -54,7 +54,7 @@ Feature: Outputting Value Objects With Forward Declarations
       @property (nonatomic, readonly) NSUInteger numberOfRatings;
       @property (nonatomic, readonly, copy) RMProxy *proxy;
       @property (nonatomic, readonly, copy) NSArray<RMSomeType *> *followers;
-      @property (nonatomic, readonly, copy) id<HelloProtocol> helloObj;
+      @property (nonatomic, readonly) id<HelloProtocol> helloObj;
       @property (nonatomic, readonly, copy) UIViewController<WorldProtocol> *worldVc;
 
       + (instancetype)new NS_UNAVAILABLE;
@@ -86,7 +86,7 @@ Feature: Outputting Value Objects With Forward Declarations
           _numberOfRatings = numberOfRatings;
           _proxy = [proxy copy];
           _followers = [followers copy];
-          _helloObj = [helloObj copy];
+          _helloObj = helloObj;
           _worldVc = [worldVc copy];
         }
 

--- a/src/object-spec-code-utils.ts
+++ b/src/object-spec-code-utils.ts
@@ -70,7 +70,13 @@ export function propertyOwnershipModifierForAttribute(supportsValueSemantics:boo
   }
   return ObjCTypeUtils.matchType({
     id: function() {
-      return propertyModifierForCopyable(supportsValueSemantics)
+      return Maybe.match(
+        function (protocol) {
+          return ObjC.PropertyModifier.Assign();
+        },
+        function () {
+          return propertyModifierForCopyable(supportsValueSemantics)
+        }, attribute.type.conformingProtocol);
     },
     NSObject: function() {
       return propertyModifierForCopyable(supportsValueSemantics)


### PR DESCRIPTION
In one of my previous commit, I added string matching to detect protocols, and that resulted in properties like
`id<protocol> hello`
being properly matched as an id type instead of unmatched type, which results in the property being generated with copy semantics

```
@property (nonatomic, readonly, copy) id<protocol> hello;
...
_hello = [hello copy];
```

I had thought this was okay and actually fixes a bug, since previously,
`id hello`
generates with copy semantics as well
```
@property (nonatomic, readonly, copy) id hello;
...
_hello = [hello copy];
```

but as it turns out, `id hello` has the copy selector, but `id<protocol> hello` doesn't (unless protocol has it). Which makes it unintendedly restricting. So I'm changing id<protocol> properties back to assign semantics instead of copy.