### PR TITLE
Assert for parameters marked as nonnull to actually be nonnull (both explicitly or using RMAssumeNonnull)

### DIFF
--- a/features/assume-nonnull.feature
+++ b/features/assume-nonnull.feature
@@ -171,6 +171,7 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
 
       + (instancetype)bazWithAString:(NSString *)aString bString:(nullable NSString *)bString
       {
+        NSParameterAssert(aString != nil);
         RMFoo *object = [[RMFoo alloc] internalInit];
         object->_subtype = _RMFooSubtypesBaz;
         object->_baz_aString = aString;

--- a/features/assume-nonnull.feature
+++ b/features/assume-nonnull.feature
@@ -47,6 +47,7 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
       - (instancetype)initWithAString:(NSString *)aString bString:(nullable NSString *)bString
       {
         if ((self = [super init])) {
+          NSParameterAssert(aString != nil);
           _aString = [aString copy];
           _bString = [bString copy];
         }

--- a/features/nullability.feature
+++ b/features/nullability.feature
@@ -43,6 +43,7 @@ Feature: Outputting Objects With Nullability Annotations
       - (instancetype)initWithName:(nullable NSString *)name identifier:(nonnull NSString *)identifier
       {
         if ((self = [super init])) {
+          NSParameterAssert(identifier != nil);
           _name = [name copy];
           _identifier = [identifier copy];
         }

--- a/features/nullability.feature
+++ b/features/nullability.feature
@@ -171,6 +171,7 @@ Feature: Outputting Objects With Nullability Annotations
 
       + (instancetype)firstSubtypeWithFirstValue:(nonnull NSString *)firstValue secondValue:(NSUInteger)secondValue
       {
+        NSParameterAssert(firstValue != nil);
         SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesFirstSubtype;
         object->_firstSubtype_firstValue = firstValue;

--- a/src/objc-nullability-utils.ts
+++ b/src/objc-nullability-utils.ts
@@ -9,6 +9,7 @@
 
 import Maybe = require('./maybe');
 import ObjC = require('./objc');
+import ObjCTypeUtils = require('./objc-type-utils');
 
 export function keywordArgumentModifiersForNullability(nullability:ObjC.Nullability):ObjC.KeywordArgumentModifier[] {
   return nullability.match(
@@ -34,4 +35,92 @@ export function propertyModifiersForNullability(nullability:ObjC.Nullability):Ob
     function nullable() {
       return [ObjC.PropertyModifier.Nullable()];
     });
+}
+
+export function shouldProtectFromNilValuesForNullability(assumeNonnull:boolean, nullability:ObjC.Nullability):boolean {
+  return nullability.match(
+    function inherited() {
+      return assumeNonnull;
+    },
+    function nonnull() {
+      return true;
+    },
+    function nullable() {
+      return false;
+    });
+}
+
+export function canAssertExistenceForType(type:ObjC.Type):boolean {
+  return ObjCTypeUtils.matchType({
+    id: function() {
+      return true;
+    },
+    NSObject: function() {
+      return true;
+    },
+    BOOL: function() {
+      return false;
+    },
+    NSInteger: function() {
+      return false;
+    },
+    NSUInteger: function() {
+      return false;
+    },
+    double: function() {
+      return false;
+    },
+    float: function() {
+      return false;
+    },
+    CGFloat: function() {
+      return false;
+    },
+    NSTimeInterval: function() {
+      return false;
+    },
+    uintptr_t: function() {
+      return false;
+    },
+    uint32_t: function() {
+      return false;
+    },
+    uint64_t: function() {
+      return false;
+    },
+    int32_t: function() {
+      return false;
+    },
+    int64_t: function() {
+      return false;
+    },
+    SEL: function() {
+      return false;
+    },
+    NSRange: function() {
+      return false;
+    },
+    CGRect: function() {
+      return false;
+    },
+    CGPoint: function() {
+      return false;
+    },
+    CGSize: function() {
+      return false;
+    },
+    UIEdgeInsets: function() {
+      return false;
+    },
+    Class: function() {
+      return true;
+    },
+    dispatch_block_t: function() {
+      return true;
+    },
+    unmatchedType: function() {
+      return false;
+    }
+  },
+  type);
 }

--- a/src/plugins/algebraic-type-initialization.ts
+++ b/src/plugins/algebraic-type-initialization.ts
@@ -139,9 +139,10 @@ function initializationClassMethodForSubtype(algebraicType:AlgebraicType.Type, s
     algebraicType.name + ' *' + nameOfObjectWithinInitializer() + ' = [[' + algebraicType.name + ' alloc] internalInit];',
     nameOfObjectWithinInitializer() + '->' + AlgebraicTypeUtils.valueAccessorForInternalPropertyStoringSubtype() + ' = ' + AlgebraicTypeUtils.EnumerationValueNameForSubtype(algebraicType, subtype) + ';'
   ];
+  const assertionsEnabled:boolean = algebraicType.excludes.indexOf('RMAssertNullability') === -1;
   const assumeNonnull:boolean = algebraicType.includes.indexOf('RMAssumeNonnull') >= 0;
   const attributes:AlgebraicType.SubtypeAttribute[] = AlgebraicTypeUtils.attributesFromSubtype(subtype);
-  const requiredParameterAssertions:string[] = attributes.filter(canAssertExistenceForTypeOfAttribute).filter(FunctionUtils.pApplyf2(assumeNonnull, isRequiredAttribute)).map(toRequiredAssertion);
+  const requiredParameterAssertions:string[] = assertionsEnabled ? attributes.filter(canAssertExistenceForTypeOfAttribute).filter(FunctionUtils.pApplyf2(assumeNonnull, isRequiredAttribute)).map(toRequiredAssertion) : [];
   const setterStatements:string[] = attributes.map(FunctionUtils.pApplyf2(subtype, internalValueSettingCodeForAttribute));
 
   return {

--- a/src/plugins/algebraic-type-initialization.ts
+++ b/src/plugins/algebraic-type-initialization.ts
@@ -122,16 +122,31 @@ function internalInitInstanceMethod() {
   }; 
 }
 
+function canAssertExistenceForTypeOfAttribute(attribute:AlgebraicType.SubtypeAttribute) {
+  return ObjCNullabilityUtils.canAssertExistenceForType(AlgebraicTypeUtils.computeTypeOfAttribute(attribute));
+}
+
+function isRequiredAttribute(assumeNonnull:boolean, attribute:AlgebraicType.SubtypeAttribute):boolean {
+  return ObjCNullabilityUtils.shouldProtectFromNilValuesForNullability(assumeNonnull, attribute.nullability);
+}
+
+function toRequiredAssertion(attribute:AlgebraicType.SubtypeAttribute):string {
+  return 'NSParameterAssert(' + attribute.name + ' != nil);';
+}
+
 function initializationClassMethodForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype):ObjC.Method {
   const openingCode:string[] = [
     algebraicType.name + ' *' + nameOfObjectWithinInitializer() + ' = [[' + algebraicType.name + ' alloc] internalInit];',
     nameOfObjectWithinInitializer() + '->' + AlgebraicTypeUtils.valueAccessorForInternalPropertyStoringSubtype() + ' = ' + AlgebraicTypeUtils.EnumerationValueNameForSubtype(algebraicType, subtype) + ';'
   ];
-  const setterStatements:string[] = AlgebraicTypeUtils.attributesFromSubtype(subtype).map(FunctionUtils.pApplyf2(subtype, internalValueSettingCodeForAttribute));
+  const assumeNonnull:boolean = algebraicType.includes.indexOf('RMAssumeNonnull') >= 0;
+  const attributes:AlgebraicType.SubtypeAttribute[] = AlgebraicTypeUtils.attributesFromSubtype(subtype);
+  const requiredParameterAssertions:string[] = attributes.filter(canAssertExistenceForTypeOfAttribute).filter(FunctionUtils.pApplyf2(assumeNonnull, isRequiredAttribute)).map(toRequiredAssertion);
+  const setterStatements:string[] = attributes.map(FunctionUtils.pApplyf2(subtype, internalValueSettingCodeForAttribute));
 
   return {
     belongsToProtocol:Maybe.Nothing<string>(),
-    code: openingCode.concat(setterStatements).concat('return object;'),
+    code: requiredParameterAssertions.concat(openingCode).concat(setterStatements).concat('return object;'),
     comments: ObjCCommentUtils.commentsAsBlockFromStringArray(commentsForSubtype(subtype)),
     compilerAttributes:[],
     keywords: keywordsForSubtype(subtype),

--- a/src/plugins/immutable-properties.ts
+++ b/src/plugins/immutable-properties.ts
@@ -72,9 +72,9 @@ function toRequiredAssertion(attribute:ObjectSpec.Attribute):string {
   return 'NSParameterAssert(' + attribute.name + ' != nil);';
 }
 
-function initializerCodeFromAttributes(assumeNonnull:boolean, supportsValueSemantics:boolean, attributes:ObjectSpec.Attribute[]):string[] {
+function initializerCodeFromAttributes(assertionsEnabled:boolean, assumeNonnull:boolean, supportsValueSemantics:boolean, attributes:ObjectSpec.Attribute[]):string[] {
   const opening = ['if ((self = [super init])) {'];
-  const requiredParameterAssertions = attributes.filter(canAssertExistenceForTypeOfAttribute).filter(FunctionUtils.pApplyf2(assumeNonnull, isRequiredAttribute)).map(toRequiredAssertion).map(StringUtils.indent(2));
+  const requiredParameterAssertions = assertionsEnabled ? attributes.filter(canAssertExistenceForTypeOfAttribute).filter(FunctionUtils.pApplyf2(assumeNonnull, isRequiredAttribute)).map(toRequiredAssertion).map(StringUtils.indent(2)) : [];
   const iVarAssignements = attributes.map(FunctionUtils.pApplyf2(supportsValueSemantics, toIvarAssignment)).map(StringUtils.indent(2));
   const closing = [
     '}',
@@ -84,11 +84,11 @@ function initializerCodeFromAttributes(assumeNonnull:boolean, supportsValueSeman
   return opening.concat(requiredParameterAssertions).concat(iVarAssignements).concat(closing);
 }
 
-function initializerFromAttributes(assumeNonnull:boolean, supportsValueSemantics:boolean, attributes:ObjectSpec.Attribute[]):ObjC.Method {
+function initializerFromAttributes(assertionsEnabled:boolean, assumeNonnull:boolean, supportsValueSemantics:boolean, attributes:ObjectSpec.Attribute[]):ObjC.Method {
   const keywords = [firstInitializerKeyword(attributes[0])].concat(attributes.slice(1).map(attributeToKeyword));
   return {
     belongsToProtocol: Maybe.Nothing<string>(),
-    code: initializerCodeFromAttributes(assumeNonnull, supportsValueSemantics, attributes),
+    code: initializerCodeFromAttributes(assertionsEnabled, assumeNonnull, supportsValueSemantics, attributes),
     comments:[],
     compilerAttributes:["NS_DESIGNATED_INITIALIZER"],
     keywords: keywords,
@@ -281,8 +281,9 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     instanceMethods: function(objectType:ObjectSpec.Type):ObjC.Method[] {
       if (objectType.attributes.length > 0) {
+        const assertionsEnabled:boolean = objectType.excludes.indexOf('RMAssertNullability') === -1;
         const assumeNonnull:boolean = objectType.includes.indexOf('RMAssumeNonnull') >= 0;
-        return [initializerFromAttributes(assumeNonnull, ObjectSpecUtils.typeSupportsValueObjectSemantics(objectType), objectType.attributes)];
+        return [initializerFromAttributes(assertionsEnabled, assumeNonnull, ObjectSpecUtils.typeSupportsValueObjectSemantics(objectType), objectType.attributes)];
       } else {
         return [];
       }

--- a/src/plugins/immutable-properties.ts
+++ b/src/plugins/immutable-properties.ts
@@ -60,97 +60,16 @@ function toIvarAssignment(supportsValueSemantics:boolean, attribute:ObjectSpec.A
   return '_' + attribute.name + ' = ' + valueOrCopy(supportsValueSemantics, attribute);
 }
 
+function canAssertExistenceForTypeOfAttribute(attribute:ObjectSpec.Attribute) {
+  return ObjCNullabilityUtils.canAssertExistenceForType(ObjectSpecCodeUtils.computeTypeOfAttribute(attribute));
+}
+
 function isRequiredAttribute(assumeNonnull:boolean, attribute:ObjectSpec.Attribute):boolean {
-  return attribute.nullability.match(
-    function inherited() {
-      return assumeNonnull;
-    },
-    function nonnull() {
-      return true;
-    },
-    function nullable() {
-      return false;
-    });
+  return ObjCNullabilityUtils.shouldProtectFromNilValuesForNullability(assumeNonnull, attribute.nullability);
 }
 
 function toRequiredAssertion(attribute:ObjectSpec.Attribute):string {
   return 'NSParameterAssert(' + attribute.name + ' != nil);';
-}
-
-function canAssertExistenceForTypeOfAttribute(attribute:ObjectSpec.Attribute):boolean {
-  const type = ObjectSpecCodeUtils.computeTypeOfAttribute(attribute);
-  return ObjCTypeUtils.matchType({
-    id: function() {
-      return true;
-    },
-    NSObject: function() {
-      return true;
-    },
-    BOOL: function() {
-      return false;
-    },
-    NSInteger: function() {
-      return false;
-    },
-    NSUInteger: function() {
-      return false;
-    },
-    double: function() {
-      return false;
-    },
-    float: function() {
-      return false;
-    },
-    CGFloat: function() {
-      return false;
-    },
-    NSTimeInterval: function() {
-      return false;
-    },
-    uintptr_t: function() {
-      return false;
-    },
-    uint32_t: function() {
-      return false;
-    },
-    uint64_t: function() {
-      return false;
-    },
-    int32_t: function() {
-      return false;
-    },
-    int64_t: function() {
-      return false;
-    },
-    SEL: function() {
-      return false;
-    },
-    NSRange: function() {
-      return false;
-    },
-    CGRect: function() {
-      return false;
-    },
-    CGPoint: function() {
-      return false;
-    },
-    CGSize: function() {
-      return false;
-    },
-    UIEdgeInsets: function() {
-      return false;
-    },
-    Class: function() {
-      return true;
-    },
-    dispatch_block_t: function() {
-      return true;
-    },
-    unmatchedType: function() {
-      return false;
-    }
-  },
-  type);
 }
 
 function initializerCodeFromAttributes(assumeNonnull:boolean, supportsValueSemantics:boolean, attributes:ObjectSpec.Attribute[]):string[] {


### PR DESCRIPTION
This adds a new `%required` annotation to mark required parameters.
All parameters that are marked as required will assert to not be `nil` in the initializer.

This is somewhat of a duplicate syntax and it would be nice if we could piggyback on the nullability stuff instead. That means we could always assert, if an attribute is marked as `nonnull` or if `RMAssumeNonnull` is enabled and the attribute isn't marked as `nullable`.

But I couldn't figure out yet how to do it that way. So I would need some help here.
Also I'm wondering if that is something we want to do by default or not.

Thus opening this for discussion.