### PR TITLE
Add an assert-nullability plugin, which generates a C function for assertions

### DIFF
--- a/features/assume-nonnull.feature
+++ b/features/assume-nonnull.feature
@@ -40,14 +40,18 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
       """
       #import "RMFoo.h"
 
+      static void RMParameterAssert(BOOL condition) {
+        NSParameterAssert(condition);
+      }
+
       NS_ASSUME_NONNULL_BEGIN
 
       @implementation RMFoo
 
       - (instancetype)initWithAString:(NSString *)aString bString:(nullable NSString *)bString
       {
+        RMParameterAssert(aString != nil);
         if ((self = [super init])) {
-          NSParameterAssert(aString != nil);
           _aString = [aString copy];
           _bString = [bString copy];
         }
@@ -153,6 +157,10 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
         _RMFooSubtypesBaz
       };
 
+      static void RMParameterAssert(BOOL condition) {
+        NSParameterAssert(condition);
+      }
+
       NS_ASSUME_NONNULL_BEGIN
 
       @implementation RMFoo
@@ -171,7 +179,7 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
 
       + (instancetype)bazWithAString:(NSString *)aString bString:(nullable NSString *)bString
       {
-        NSParameterAssert(aString != nil);
+        RMParameterAssert(aString != nil);
         RMFoo *object = [[RMFoo alloc] internalInit];
         object->_subtype = _RMFooSubtypesBaz;
         object->_baz_aString = aString;

--- a/features/nullability.feature
+++ b/features/nullability.feature
@@ -38,12 +38,16 @@ Feature: Outputting Objects With Nullability Annotations
       """
       #import "RMPage.h"
 
+      static void RMParameterAssert(BOOL condition) {
+        NSParameterAssert(condition);
+      }
+
       @implementation RMPage
 
       - (instancetype)initWithName:(nullable NSString *)name identifier:(nonnull NSString *)identifier
       {
+        RMParameterAssert(identifier != nil);
         if ((self = [super init])) {
-          NSParameterAssert(identifier != nil);
           _name = [name copy];
           _identifier = [identifier copy];
         }
@@ -160,6 +164,10 @@ Feature: Outputting Objects With Nullability Annotations
         _SimpleADTSubtypesSecondSubtype
       };
 
+      static void RMParameterAssert(BOOL condition) {
+        NSParameterAssert(condition);
+      }
+
       @implementation SimpleADT
       {
         _SimpleADTSubtypes _subtype;
@@ -171,7 +179,7 @@ Feature: Outputting Objects With Nullability Annotations
 
       + (instancetype)firstSubtypeWithFirstValue:(nonnull NSString *)firstValue secondValue:(NSUInteger)secondValue
       {
-        NSParameterAssert(firstValue != nil);
+        RMParameterAssert(firstValue != nil);
         SimpleADT *object = [[SimpleADT alloc] internalInit];
         object->_subtype = _SimpleADTSubtypesFirstSubtype;
         object->_firstSubtype_firstValue = firstValue;

--- a/src/algebraic-types.ts
+++ b/src/algebraic-types.ts
@@ -45,6 +45,7 @@ interface PathAndTypeInfo {
 
 const BASE_INCLUDES:List.List<string> = List.of(
   'AlgebraicTypeInitialization',
+  'RMAssertNullability',
   'RMCopying',
   'RMDescription',
   'RMEquality',
@@ -54,6 +55,7 @@ const BASE_INCLUDES:List.List<string> = List.of(
 
 const BASE_PLUGINS:List.List<string> = List.of(
   'algebraic-type-initialization',
+  'assert-nullability',
   'assume-nonnull',
   'coding',
   'copying',

--- a/src/objc-nullability-utils.ts
+++ b/src/objc-nullability-utils.ts
@@ -50,6 +50,15 @@ export function shouldProtectFromNilValuesForNullability(assumeNonnull:boolean, 
     });
 }
 
+export function nullabilityRequiresNonnullProtection(assumeNonnull:boolean, attributeNullabilities:ObjC.Nullability[]):boolean {
+  for (var i = attributeNullabilities.length - 1; i >= 0; i--) {
+    if(shouldProtectFromNilValuesForNullability(assumeNonnull, attributeNullabilities[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function canAssertExistenceForType(type:ObjC.Type):boolean {
   return ObjCTypeUtils.matchType({
     id: function() {

--- a/src/objc-nullability-utils.ts
+++ b/src/objc-nullability-utils.ts
@@ -51,12 +51,7 @@ export function shouldProtectFromNilValuesForNullability(assumeNonnull:boolean, 
 }
 
 export function nullabilityRequiresNonnullProtection(assumeNonnull:boolean, attributeNullabilities:ObjC.Nullability[]):boolean {
-  for (var i = attributeNullabilities.length - 1; i >= 0; i--) {
-    if(shouldProtectFromNilValuesForNullability(assumeNonnull, attributeNullabilities[i])) {
-      return true;
-    }
-  }
-  return false;
+  return attributeNullabilities.some(nullability => shouldProtectFromNilValuesForNullability(assumeNonnull, nullability));
 }
 
 export function canAssertExistenceForType(type:ObjC.Type):boolean {

--- a/src/object-spec-default-config.ts
+++ b/src/object-spec-default-config.ts
@@ -12,11 +12,13 @@ import List = require('./list')
 
 export const OBJECT_SPEC_DEFAULT_CONFIG = {
   baseIncludes: List.of(
+    'RMAssertNullability',
     'RMDescription',
     'RMImmutableProperties',
     'RMInitNewUnavailable'
   ),
   basePlugins: List.of(
+    'assert-nullability',
     'assume-nonnull',
     'builder',
     'coding',

--- a/src/plugins/algebraic-type-initialization.ts
+++ b/src/plugins/algebraic-type-initialization.ts
@@ -131,7 +131,7 @@ function isRequiredAttribute(assumeNonnull:boolean, attribute:AlgebraicType.Subt
 }
 
 function toRequiredAssertion(attribute:AlgebraicType.SubtypeAttribute):string {
-  return 'NSParameterAssert(' + attribute.name + ' != nil);';
+  return 'RMParameterAssert(' + attribute.name + ' != nil);';
 }
 
 function initializationClassMethodForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype):ObjC.Method {
@@ -139,10 +139,9 @@ function initializationClassMethodForSubtype(algebraicType:AlgebraicType.Type, s
     algebraicType.name + ' *' + nameOfObjectWithinInitializer() + ' = [[' + algebraicType.name + ' alloc] internalInit];',
     nameOfObjectWithinInitializer() + '->' + AlgebraicTypeUtils.valueAccessorForInternalPropertyStoringSubtype() + ' = ' + AlgebraicTypeUtils.EnumerationValueNameForSubtype(algebraicType, subtype) + ';'
   ];
-  const assertionsEnabled:boolean = algebraicType.excludes.indexOf('RMAssertNullability') === -1;
   const assumeNonnull:boolean = algebraicType.includes.indexOf('RMAssumeNonnull') >= 0;
   const attributes:AlgebraicType.SubtypeAttribute[] = AlgebraicTypeUtils.attributesFromSubtype(subtype);
-  const requiredParameterAssertions:string[] = assertionsEnabled ? attributes.filter(canAssertExistenceForTypeOfAttribute).filter(FunctionUtils.pApplyf2(assumeNonnull, isRequiredAttribute)).map(toRequiredAssertion) : [];
+  const requiredParameterAssertions:string[] = attributes.filter(canAssertExistenceForTypeOfAttribute).filter(FunctionUtils.pApplyf2(assumeNonnull, isRequiredAttribute)).map(toRequiredAssertion);
   const setterStatements:string[] = attributes.map(FunctionUtils.pApplyf2(subtype, internalValueSettingCodeForAttribute));
 
   return {

--- a/src/plugins/assert-nullability.ts
+++ b/src/plugins/assert-nullability.ts
@@ -41,8 +41,8 @@ function parameterAssertFunction():ObjC.Function {
   };
 }
 
-function parameterAssertFunctionArrayIfNeeded(assumeNonnull:boolean, attributeNullabilities:ObjC.Nullability[]):ObjC.Function[] {
-  if(ObjCNullabilityUtils.nullabilityRequiresNonnullProtection(assumeNonnull, attributeNullabilities)) {
+function parameterAssertFunctionArray(assumeNonnull:boolean, attributeNullabilities:ObjC.Nullability[]):ObjC.Function[] {
+  if (ObjCNullabilityUtils.nullabilityRequiresNonnullProtection(assumeNonnull, attributeNullabilities)) {
     return [parameterAssertFunction()];
   } else {
     return [];
@@ -75,7 +75,7 @@ export function createPlugin():ObjectSpec.Plugin {
     functions: function(objectType:ObjectSpec.Type):ObjC.Function[] {
       const assumeNonnull:boolean = objectType.includes.indexOf('RMAssumeNonnull') >= 0;
       const attributeNullabilities = objectType.attributes.map(attribute => attribute.nullability);
-      return parameterAssertFunctionArrayIfNeeded(assumeNonnull, attributeNullabilities);
+      return parameterAssertFunctionArray(assumeNonnull, attributeNullabilities);
     },
     headerComments: function(objectType:ObjectSpec.Type):ObjC.Comment[] {
       return [];
@@ -131,7 +131,7 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     functions: function(algebraicType:AlgebraicType.Type):ObjC.Function[] {
       const assumeNonnull:boolean = algebraicType.includes.indexOf('RMAssumeNonnull') >= 0;
       const attributeNullabilities = AlgebraicTypeUtils.allAttributesFromSubtypes(algebraicType.subtypes).map(attribute => attribute.nullability);
-      return parameterAssertFunctionArrayIfNeeded(assumeNonnull, attributeNullabilities);
+      return parameterAssertFunctionArray(assumeNonnull, attributeNullabilities);
     },
     headerComments: function(algebraicType:AlgebraicType.Type):ObjC.Comment[] {
       return [];

--- a/src/plugins/assert-nullability.ts
+++ b/src/plugins/assert-nullability.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import AlgebraicType = require('../algebraic-type');
+import AlgebraicTypeUtils = require('../algebraic-type-utils');
+import Code = require('../code');
+import Error = require('../error');
+import FileWriter = require('../file-writer');
+import Maybe = require('../maybe');
+import ObjC = require('../objc');
+import ObjCNullabilityUtils = require('../objc-nullability-utils');
+import ObjectSpec = require('../object-spec');
+
+function parameterAssertFunction():ObjC.Function {
+  return {
+    comments: [],
+    name: 'RMParameterAssert',
+    parameters: [
+      {
+        type: {
+          name: 'BOOL',
+          reference: 'BOOL'
+        },
+        name: 'condition'
+      }
+    ],
+    returnType: {
+      type: Maybe.Nothing<ObjC.Type>(),
+      modifiers: []
+    },
+    code: [
+      'NSParameterAssert(condition);'
+    ],
+    isPublic: false
+  };
+}
+
+function parameterAssertFunctionArrayIfNeeded(assumeNonnull:boolean, attributeNullabilities:ObjC.Nullability[]):ObjC.Function[] {
+  if(ObjCNullabilityUtils.nullabilityRequiresNonnullProtection(assumeNonnull, attributeNullabilities)) {
+    return [parameterAssertFunction()];
+  } else {
+    return [];
+  }
+}
+
+export function createPlugin():ObjectSpec.Plugin {
+  return {
+    additionalFiles: function(objectType:ObjectSpec.Type):Code.File[] {
+      return [];
+    },
+    additionalTypes: function(objectType:ObjectSpec.Type):ObjectSpec.Type[] {
+      return [];
+    },
+    attributes: function(objectType:ObjectSpec.Type):ObjectSpec.Attribute[] {
+      return [];
+    },
+    classMethods: function(objectType:ObjectSpec.Type):ObjC.Method[] {
+      return [];
+    },
+    fileTransformation: function(request:FileWriter.Request):FileWriter.Request {
+      return request;
+    },
+    fileType: function(objectType:ObjectSpec.Type):Maybe.Maybe<Code.FileType> {
+      return Maybe.Nothing<Code.FileType>();
+    },
+    forwardDeclarations: function(objectType:ObjectSpec.Type):ObjC.ForwardDeclaration[] {
+      return [];
+    },
+    functions: function(objectType:ObjectSpec.Type):ObjC.Function[] {
+      const assumeNonnull:boolean = objectType.includes.indexOf('RMAssumeNonnull') >= 0;
+      const attributeNullabilities = objectType.attributes.map(attribute => attribute.nullability);
+      return parameterAssertFunctionArrayIfNeeded(assumeNonnull, attributeNullabilities);
+    },
+    headerComments: function(objectType:ObjectSpec.Type):ObjC.Comment[] {
+      return [];
+    },
+    implementedProtocols: function(objectType:ObjectSpec.Type):ObjC.Protocol[] {
+      return [];
+    },
+    imports: function(objectType:ObjectSpec.Type):ObjC.Import[] {
+      return [];
+    },
+    instanceMethods: function(objectType:ObjectSpec.Type):ObjC.Method[] {
+      return [];
+    },
+    properties: function(objectType:ObjectSpec.Type):ObjC.Property[] {
+      return [];
+    },
+    requiredIncludesToRun:['RMAssertNullability'],
+    staticConstants: function(objectType:ObjectSpec.Type):ObjC.Constant[] {
+      return [];
+    },
+    validationErrors: function(objectType:ObjectSpec.Type):Error.Error[] {
+      return [];
+    },
+    nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
+      return Maybe.Nothing<ObjC.ClassNullability>();
+    }
+  };
+}
+
+export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
+  return {
+    additionalFiles: function(algebraicType:AlgebraicType.Type):Code.File[] {
+      return [];
+    },
+    blockTypes: function(algebraicType:AlgebraicType.Type):ObjC.BlockType[] {
+      return [];
+    },
+    classMethods: function(algebraicType:AlgebraicType.Type):ObjC.Method[] {
+      return [];
+    },
+    enumerations: function(algebraicType:AlgebraicType.Type):ObjC.Enumeration[] {
+      return [];
+    },
+    fileTransformation: function(request:FileWriter.Request):FileWriter.Request {
+      return request;
+    },
+    fileType: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<Code.FileType> {
+      return Maybe.Nothing<Code.FileType>();
+    },
+    forwardDeclarations: function(algebraicType:AlgebraicType.Type):ObjC.ForwardDeclaration[] {
+      return [];
+    },
+    functions: function(algebraicType:AlgebraicType.Type):ObjC.Function[] {
+      const assumeNonnull:boolean = algebraicType.includes.indexOf('RMAssumeNonnull') >= 0;
+      const attributeNullabilities = AlgebraicTypeUtils.allAttributesFromSubtypes(algebraicType.subtypes).map(attribute => attribute.nullability);
+      return parameterAssertFunctionArrayIfNeeded(assumeNonnull, attributeNullabilities);
+    },
+    headerComments: function(algebraicType:AlgebraicType.Type):ObjC.Comment[] {
+      return [];
+    },
+    implementedProtocols: function(algebraicType:AlgebraicType.Type):ObjC.Protocol[] {
+      return [];
+    },
+    imports: function(algebraicType:AlgebraicType.Type):ObjC.Import[] {
+      return [];
+    },
+    instanceMethods: function(algebraicType:AlgebraicType.Type):ObjC.Method[] {
+      return [];
+    },
+    internalProperties: function(algebraicType:AlgebraicType.Type):ObjC.Property[] {
+      return [];
+    },
+    requiredIncludesToRun: ['RMAssertNullability'],
+    staticConstants: function(algebraicType:AlgebraicType.Type):ObjC.Constant[] {
+      return [];
+    },
+    validationErrors: function(algebraicType:AlgebraicType.Type):Error.Error[] {
+      return [];
+    },
+    nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
+      return Maybe.Nothing<ObjC.ClassNullability>();
+    }
+  };
+}

--- a/src/value-object-default-config.ts
+++ b/src/value-object-default-config.ts
@@ -12,6 +12,7 @@ import List = require('./list')
 
 export const VALUE_OBJECT_DEFAULT_CONFIG = {
   baseIncludes: List.of(
+    'RMAssertNullability',
     'RMCopying',
     'RMDescription',
     'RMEquality',
@@ -20,6 +21,7 @@ export const VALUE_OBJECT_DEFAULT_CONFIG = {
     'RMValueObjectSemantics'
   ),
   basePlugins: List.of(
+    'assert-nullability',
     'assume-nonnull',
     'builder',
     'coding',


### PR DESCRIPTION
This will enable us to write custom plugins to use a different assertion function, when needed/wanted. It's a C function so it can be fully inlined by the compiler.

This also moves the assertion call to the first line of the init method.