### PR TITLE
Nil checking

### DIFF
--- a/features/algebraic-type-forward-declaration.feature
+++ b/features/algebraic-type-forward-declaration.feature
@@ -158,15 +158,21 @@ Feature: Outputting forward declarations in Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeRandomSubtype: {
-            someRandomSubtypeMatchHandler();
+            if (someRandomSubtypeMatchHandler) {
+              someRandomSubtypeMatchHandler();
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }

--- a/features/algebraic-types-coding.feature
+++ b/features/algebraic-types-coding.feature
@@ -180,11 +180,15 @@ Feature: Outputting Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }

--- a/features/algebraic-types-cplusplus.feature
+++ b/features/algebraic-types-cplusplus.feature
@@ -154,15 +154,21 @@ Feature: Outputting ObjC++ Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeRandomSubtype: {
-            someRandomSubtypeMatchHandler();
+            if (someRandomSubtypeMatchHandler) {
+              someRandomSubtypeMatchHandler();
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }

--- a/features/algebraic-types.feature
+++ b/features/algebraic-types.feature
@@ -195,19 +195,27 @@ Feature: Outputting Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeRandomSubtype: {
-            someRandomSubtypeMatchHandler();
+            if (someRandomSubtypeMatchHandler) {
+              someRandomSubtypeMatchHandler();
+            }
             break;
           }
           case _SimpleADTSubtypesSomeAttributeSubtype: {
-            someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            if (someAttributeSubtypeMatchHandler) {
+              someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }
@@ -359,11 +367,15 @@ Feature: Outputting Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }
@@ -530,15 +542,21 @@ Feature: Outputting Algebraic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeRandomSubtype: {
-            someRandomSubtypeMatchHandler();
+            if (someRandomSubtypeMatchHandler) {
+              someRandomSubtypeMatchHandler();
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }

--- a/features/assume-nonnull.feature
+++ b/features/assume-nonnull.feature
@@ -245,11 +245,15 @@ Feature: Outputting Value Objects / Algebraic Types decorated with NS_ASSUME_NON
       {
         switch (_subtype) {
           case _RMFooSubtypesBar: {
-            barMatchHandler();
+            if (barMatchHandler) {
+              barMatchHandler();
+            }
             break;
           }
           case _RMFooSubtypesBaz: {
-            bazMatchHandler(_baz_aString, _baz_bString);
+            if (bazMatchHandler) {
+              bazMatchHandler(_baz_aString, _baz_bString);
+            }
             break;
           }
         }

--- a/features/generics.feature
+++ b/features/generics.feature
@@ -219,11 +219,15 @@ Feature: Outputting Objects With Generic Types
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_namesToAges);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_namesToAges);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeAttributeSubtype: {
-            someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            if (someAttributeSubtypeMatchHandler) {
+              someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            }
             break;
           }
         }

--- a/features/nullability.feature
+++ b/features/nullability.feature
@@ -278,19 +278,27 @@ Feature: Outputting Objects With Nullability Annotations
       {
         switch (_subtype) {
           case _SimpleADTSubtypesFirstSubtype: {
-            firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            if (firstSubtypeMatchHandler) {
+              firstSubtypeMatchHandler(_firstSubtype_firstValue, _firstSubtype_secondValue);
+            }
             break;
           }
           case _SimpleADTSubtypesSomeRandomSubtype: {
-            someRandomSubtypeMatchHandler();
+            if (someRandomSubtypeMatchHandler) {
+              someRandomSubtypeMatchHandler();
+            }
             break;
           }
           case _SimpleADTSubtypesSomeAttributeSubtype: {
-            someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            if (someAttributeSubtypeMatchHandler) {
+              someAttributeSubtypeMatchHandler(_someAttributeSubtype);
+            }
             break;
           }
           case _SimpleADTSubtypesSecondSubtype: {
-            secondSubtypeMatchHandler(_secondSubtype_something);
+            if (secondSubtypeMatchHandler) {
+              secondSubtypeMatchHandler(_secondSubtype_something);
+            }
             break;
           }
         }

--- a/src/__tests__/plugins/algebraic-type-function-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-function-matching-test.ts
@@ -205,11 +205,15 @@ describe('Plugins.AlgebraicTypeFunctionMatching', function() {
         code: [
           'switch (_subtype) {',
           '  case _TestSubtypesSomeSubtype: {',
-          '    someSubtypeMatchHandler(_someSubtype_someString, _someSubtype_someUnsignedInteger);',
+          '    if (someSubtypeMatchHandler) {',
+          '      someSubtypeMatchHandler(_someSubtype_someString, _someSubtype_someUnsignedInteger);',
+          '    }',
           '    break;',
           '  }',
           '  case _TestSubtypesSingleAttributeSubtype: {',
-          '    singleAttributeSubtypeMatchHandler(_singleAttributeSubtype);',
+          '    if (singleAttributeSubtypeMatchHandler) {',
+          '      singleAttributeSubtypeMatchHandler(_singleAttributeSubtype);',
+          '    }',
           '    break;',
           '  }',
           '}'

--- a/src/plugins/algebraic-type-function-matching.ts
+++ b/src/plugins/algebraic-type-function-matching.ts
@@ -27,12 +27,16 @@ function instanceMethodKeywordsForMatchingSubtypesOfAlgebraicType(algebraicType:
   return [firstKeyword].concat(additionalKeywords);
 }
 
-function blockInvocationForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype):string[] {
-  return [AlgebraicTypeUtils.blockParameterNameForMatchMethodFromSubtype(subtype) + '(' + AlgebraicTypeUtils.attributesFromSubtype(subtype).map(FunctionUtils.pApplyf2(subtype, AlgebraicTypeUtils.valueAccessorForInternalPropertyForAttribute)).join(', ') + ');'];
+function blockInvocationWithNilCheckForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype):string[] {
+  return ['if (' + AlgebraicTypeUtils.blockParameterNameForMatchMethodFromSubtype(subtype) + ') {', StringUtils.indent(2)(blockInvocationForSubtype(algebraicType, subtype)), '}'];
+}
+
+function blockInvocationForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype):string {
+  return AlgebraicTypeUtils.blockParameterNameForMatchMethodFromSubtype(subtype) + '(' + AlgebraicTypeUtils.attributesFromSubtype(subtype).map(FunctionUtils.pApplyf2(subtype, AlgebraicTypeUtils.valueAccessorForInternalPropertyForAttribute)).join(', ') + ');';
 }
 
 function matcherCodeForAlgebraicType(algebraicType:AlgebraicType.Type):string[] {
-  return AlgebraicTypeUtils.codeForSwitchingOnSubtypeWithSubtypeMapper(algebraicType, AlgebraicTypeUtils.valueAccessorForInternalPropertyStoringSubtype(), blockInvocationForSubtype);
+  return AlgebraicTypeUtils.codeForSwitchingOnSubtypeWithSubtypeMapper(algebraicType, AlgebraicTypeUtils.valueAccessorForInternalPropertyStoringSubtype(), blockInvocationWithNilCheckForSubtype);
 }
 
 function instanceMethodForMatchingSubtypesOfAlgebraicType(algebraicType:AlgebraicType.Type):ObjC.Method {


### PR DESCRIPTION
Resubmitting PR 21 - https://github.com/facebook/remodel/pull/21.

Adding protections such that nil blocks won't get invoked is important to protect against developer error.

Updated acceptance tests to pass.  Unit tests passed as-is from the original commit.