### PR TITLE
Add --output-path support.

### DIFF
--- a/features/output_path.feature
+++ b/features/output_path.feature
@@ -1,0 +1,97 @@
+Feature: Specifying an output directory to put results in
+
+  @announce
+  Scenario: Generating file into new directory
+    Given a file named "project/values/RMValueType.value" with:
+      """
+      # Simple file
+      RMValueType {
+        BOOL doesUserLike
+        NSString* identifier
+      }
+      """
+    And a file named "project/.valueObjectConfig" with:
+      """
+      { }
+      """
+    And a directory named "project/output":
+    When I run `../../bin/generate project --output-path=project/output`
+    Then the file "project/output/RMValueType.h" should contain:
+      """
+      #import <Foundation/Foundation.h>
+
+      /**
+       * Simple file
+       */
+      @interface RMValueType : NSObject <NSCopying>
+
+      @property (nonatomic, readonly) BOOL doesUserLike;
+      @property (nonatomic, readonly, copy) NSString *identifier;
+
+      + (instancetype)new NS_UNAVAILABLE;
+
+      - (instancetype)init NS_UNAVAILABLE;
+
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier NS_DESIGNATED_INITIALIZER;
+
+      @end
+
+      """
+   And the file "project/output/RMValueType.m" should contain:
+      """
+      #import "RMValueType.h"
+
+      @implementation RMValueType
+
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier
+      {
+        if ((self = [super init])) {
+          _doesUserLike = doesUserLike;
+          _identifier = [identifier copy];
+        }
+
+        return self;
+      }
+
+      - (id)copyWithZone:(nullable NSZone *)zone
+      {
+        return self;
+      }
+
+      - (NSString *)description
+      {
+        return [NSString stringWithFormat:@"%@ - \n\t doesUserLike: %@; \n\t identifier: %@; \n", [super description], _doesUserLike ? @"YES" : @"NO", _identifier];
+      }
+
+      - (NSUInteger)hash
+      {
+        NSUInteger subhashes[] = {(NSUInteger)_doesUserLike, [_identifier hash]};
+        NSUInteger result = subhashes[0];
+        for (int ii = 1; ii < 2; ++ii) {
+          unsigned long long base = (((unsigned long long)result) << 32 | subhashes[ii]);
+          base = (~base) + (base << 18);
+          base ^= (base >> 31);
+          base *=  21;
+          base ^= (base >> 11);
+          base += (base << 6);
+          base ^= (base >> 22);
+          result = base;
+        }
+        return result;
+      }
+
+      - (BOOL)isEqual:(RMValueType *)object
+      {
+        if (self == object) {
+          return YES;
+        } else if (self == nil || object == nil || ![object isKindOfClass:[self class]]) {
+          return NO;
+        }
+        return
+          _doesUserLike == object->_doesUserLike &&
+          (_identifier == object->_identifier ? YES : [_identifier isEqual:object->_identifier]);
+      }
+
+      @end
+
+      """

--- a/features/step_definitions/cliStepDefinitions.js
+++ b/features/step_definitions/cliStepDefinitions.js
@@ -55,6 +55,11 @@ module.exports = function() {
     callback();
   });
 
+  this.Given(/^a directory named "([^"]*)":$/, function(dirName, callback) {
+    mkdirp.sync(this.tmpDirectoryPath + '/' + dirName);
+    callback();
+  });
+
   this.When(/^I run `([^`]*)`$/, function(cmd, callback) {
     run(unescape(cmd), this.tmpDirectoryPath, callback);
   });

--- a/src/algebraic-types.ts
+++ b/src/algebraic-types.ts
@@ -29,6 +29,7 @@ import Promise = require('./promise');
 import ReadFileUtils = require('./file-logged-sequence-read-utils');
 import RequirePlugin = require('./require-plugin');
 import WriteFileUtils = require('./file-logged-sequence-write-utils');
+import path = require('path');
 
 interface AlgebraicTypeCreationContext {
   baseClassName:string;
@@ -91,7 +92,7 @@ function typeInformationContainingDefaultIncludes(typeInformation:AlgebraicType.
   };
 }
 
-function processAlgebraicTypeCreationRequest(future:Promise.Future<Either.Either<Error.Error[], AlgebraicTypeCreationContext>>, either:Either.Either<Error.Error[], PathAndTypeInfo>):Promise.Future<Logging.Context<Either.Either<Error.Error[], FileWriter.FileWriteRequest>>> {
+function processAlgebraicTypeCreationRequest(outputPath:Maybe.Maybe<File.AbsoluteFilePath>, future:Promise.Future<Either.Either<Error.Error[], AlgebraicTypeCreationContext>>, either:Either.Either<Error.Error[], PathAndTypeInfo>):Promise.Future<Logging.Context<Either.Either<Error.Error[], FileWriter.FileWriteRequest>>> {
   return Promise.map(function(creationContextEither:Either.Either<Error.Error[], AlgebraicTypeCreationContext>) {
     return Logging.munit(Either.mbind(function(pathAndTypeInfo:PathAndTypeInfo) {
       return Either.mbind(function(creationContext:AlgebraicTypeCreationContext) {
@@ -100,6 +101,7 @@ function processAlgebraicTypeCreationRequest(future:Promise.Future<Either.Either
           baseClassLibraryName:creationContext.baseClassLibraryName,
           baseClassName:creationContext.baseClassName,
           path:pathAndTypeInfo.path,
+          outputPath:outputPath,
           typeInformation:typeInformationContainingDefaultIncludes(pathAndTypeInfo.typeInformation, creationContext.defaultIncludes)
         };
 
@@ -154,8 +156,18 @@ function getAlgebraicTypeCreationContext(currentWorkingDirectory:File.AbsoluteFi
   }, findConfigFuture);
 }
 
+function outputDirectory(directoryRunFrom:string, outputPath:string):Maybe.Maybe<File.AbsoluteFilePath> {
+  if (outputPath === undefined || outputPath === "") {
+    return Maybe.Nothing<File.AbsoluteFilePath>();  
+  } else {
+    return Maybe.Just<File.AbsoluteFilePath>(PathUtils.getAbsolutePathFromDirectoryAndAbsoluteOrRelativePath(File.getAbsoluteFilePath(directoryRunFrom), outputPath));
+  }
+}
+
 export function generate(directoryRunFrom:string, parsedArgs:CommandLine.Arguments):Promise.Future<WriteFileUtils.ConsoleOutputResults> {
     const requestedPath:File.AbsoluteFilePath = PathUtils.getAbsolutePathFromDirectoryAndAbsoluteOrRelativePath(File.getAbsoluteFilePath(directoryRunFrom), parsedArgs.givenPath);
+    const outputPath:Maybe.Maybe<File.AbsoluteFilePath> = outputDirectory(directoryRunFrom, parsedArgs.outputPath);
+
     const algebraicTypeCreationContextFuture = getAlgebraicTypeCreationContext(requestedPath);
 
     const readFileSequence = ReadFileUtils.loggedSequenceThatReadsFiles(requestedPath, 'adtValue');
@@ -164,7 +176,7 @@ export function generate(directoryRunFrom:string, parsedArgs:CommandLine.Argumen
                                                                   parseValues);
 
     const pluginProcessedSequence = LoggingSequenceUtils.mapLoggedSequence(parsedSequence,
-                                                                           FunctionUtils.pApplyf2(algebraicTypeCreationContextFuture, processAlgebraicTypeCreationRequest));
+                                                                           FunctionUtils.pApply2f3(outputPath, algebraicTypeCreationContextFuture, processAlgebraicTypeCreationRequest));
 
     return WriteFileUtils.evaluateObjectFileWriteRequestSequence(parsedArgs, pluginProcessedSequence);
 }

--- a/src/commandline.ts
+++ b/src/commandline.ts
@@ -22,6 +22,7 @@ export interface Arguments {
   interestedLoggingTypes:List.List<Logging.LoggingType>;
   minimalLevel:number;
   dryRun:boolean;
+  outputPath:string;
 }
 
 const VERBOSE_FLAG:string = 'verbose';
@@ -29,6 +30,7 @@ const PERF_LOGGING_FLAG:string = 'perf-log';
 const DEBUG_LOGGING_FLAG:string = 'debug';
 const SILENT_LOGGING_FLAG:string = 'silent';
 const DRY_RUN_FLAG:string = 'dry-run';
+const OUTPUT_PATH:string = 'output-path';
 
 const ADT_CONFIG_PATH:string = 'adt-config-path';
 const VALUE_OBJECT_CONFIG_PATH:string = 'value-object-config-path';
@@ -62,7 +64,8 @@ export function parseArgs(args:string[]):Maybe.Maybe<Arguments> {
       objectConfigPath:parsedArgs[OBJECT_CONFIG_PATH],
       interestedLoggingTypes:interestedTypesForArgs(parsedArgs),
       minimalLevel:parsedArgs[VERBOSE_FLAG] ? 1 : 10,
-      dryRun:parsedArgs[DRY_RUN_FLAG]
+      dryRun:parsedArgs[DRY_RUN_FLAG],
+      outputPath:parsedArgs[OUTPUT_PATH],
     });
   }
 }

--- a/src/object-spec-creation.ts
+++ b/src/object-spec-creation.ts
@@ -168,6 +168,7 @@ export function fileWriteRequest(request:Request, plugins:List.List<ObjectSpec.P
     baseClassLibraryName:request.baseClassLibraryName,
     baseClassName:request.baseClassName,
     path:request.path,
+    outputPath:request.outputPath,
     typeInformation:typeInformationWithAllAttributesFromPlugins(request.typeInformation, pluginsToRun)
   };
 


### PR DESCRIPTION
This allows the user to specify a different directory for output, as opposed to putting the files side-by-side. It is designed to be used in conjunction with passing a real file path, not a path to a directory, though it would certainly work in the latter case too if desired.

This is all to improve the way we build remodel files with buck. At present, we copy remodel files into temp directories and run the command there. This is not efficient. This will allow us to keep the source where it is and put the output where we want it without shenanigans.

I tried to do the best I could wrt how it fits into the flow, but if there are suggestions on how to improve it, I'm sure you'll let me know :-)