### PR TITLE
Fix issue where the library name was not being considered

### DIFF
--- a/src/plugins/algebraic-type-templated-matching.ts
+++ b/src/plugins/algebraic-type-templated-matching.ts
@@ -130,7 +130,7 @@ function matchingFileForAlgebraicType(algebraicType:AlgebraicType.Type):Code.Fil
     type: Code.FileType.ObjectiveCPlusPlus(),
     imports:[
       {file:'Foundation.h', isPublic:true, library:Maybe.Just<string>('Foundation')},
-      {file:algebraicType.name + '.h', isPublic:true, library:Maybe.Nothing<string>()},
+      {file:algebraicType.name + '.h', isPublic:true, library:algebraicType.libraryName},
       {file:matchingFileNameForAlgebraicType(algebraicType) + '.h', isPublic:false, library:Maybe.Nothing<string>()},
       {file:'memory', isPublic:true, library:Maybe.Nothing<string>()}
     ],


### PR DESCRIPTION
Fix issue where the library name was not being considered when outputting the templated matching header

I ran into an issue where the plugin for Templated Matching headers did not correctly output the import of the main object header. Instead of using the library name from the algebraic type, it simply used Maybe.Nothing(), which ended up outputting a local import and not a framework-style import.

Acceptance and unit tests pass.