### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,9 @@ Before you dig in, you should keep in mind that Remodel has an extensibility mod
 
 In the cases where Remodel itself does need updates, we will welcome your pull requests.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 ## Our Development Process
 
 We use GitHub to sync code to and from our internal repository. We'll use GitHub to track issues and feature requests, as well as accept pull requests.


### PR DESCRIPTION
**what is the change?:**
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [remodel's Community Profile](https://github.com/facebook/remodel/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1488" alt="screen shot 2018-01-11 at 6 41 31 am" src="https://user-images.githubusercontent.com/1114467/34831064-b1f13b2e-f69a-11e7-9fde-827b48b51265.png">
<img width="1497" alt="screen shot 2018-01-11 at 6 41 41 am" src="https://user-images.githubusercontent.com/1114467/34831065-b23f02be-f69a-11e7-8edd-57b14139b506.png">

**issue:**
internal task t23481323