### PR TITLE
 Adding --include, --exclude, and --prohibit-embedded-includes parameters

### DIFF
--- a/features/cmd-line-includes.feature
+++ b/features/cmd-line-includes.feature
@@ -176,5 +176,5 @@ Feature: Controlling includes/excludes from command line
       """
       { }
       """
-    When I run `../../bin/generate project --prohibit-embedded-includes`
+    When I run `../../bin/generate project --prohibit-plugin-directives`
     Then the file "project/values/RMValueType.h" should not exist

--- a/features/cmd-line-includes.feature
+++ b/features/cmd-line-includes.feature
@@ -1,0 +1,180 @@
+Feature: Controlling includes/excludes from command line
+
+  @announce
+  Scenario: Add builder via command line
+    Given a file named "project/values/RMValueType.value" with:
+      """
+      # Simple file
+      RMValueType {
+        BOOL doesUserLike
+        NSString* identifier
+      }
+      """
+    And a file named "project/.valueObjectConfig" with:
+      """
+      { }
+      """
+    When I run `../../bin/generate project --include=RMBuilder`
+    Then the file "project/values/RMValueType.h" should contain:
+      """
+      #import <Foundation/Foundation.h>
+
+      /**
+       * Simple file
+       */
+      @interface RMValueType : NSObject <NSCopying>
+
+      @property (nonatomic, readonly) BOOL doesUserLike;
+      @property (nonatomic, readonly, copy) NSString *identifier;
+
+      + (instancetype)new NS_UNAVAILABLE;
+
+      - (instancetype)init NS_UNAVAILABLE;
+
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier NS_DESIGNATED_INITIALIZER;
+
+      @end
+
+      """
+   And the file "project/values/RMValueType.m" should contain:
+      """
+      #import "RMValueType.h"
+
+      @implementation RMValueType
+
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier
+      {
+        if ((self = [super init])) {
+          _doesUserLike = doesUserLike;
+          _identifier = [identifier copy];
+        }
+
+        return self;
+      }
+
+      - (id)copyWithZone:(nullable NSZone *)zone
+      {
+        return self;
+      }
+
+      - (NSString *)description
+      {
+        return [NSString stringWithFormat:@"%@ - \n\t doesUserLike: %@; \n\t identifier: %@; \n", [super description], _doesUserLike ? @"YES" : @"NO", _identifier];
+      }
+
+      - (NSUInteger)hash
+      {
+        NSUInteger subhashes[] = {(NSUInteger)_doesUserLike, [_identifier hash]};
+        NSUInteger result = subhashes[0];
+        for (int ii = 1; ii < 2; ++ii) {
+          unsigned long long base = (((unsigned long long)result) << 32 | subhashes[ii]);
+          base = (~base) + (base << 18);
+          base ^= (base >> 31);
+          base *=  21;
+          base ^= (base >> 11);
+          base += (base << 6);
+          base ^= (base >> 22);
+          result = base;
+        }
+        return result;
+      }
+
+      - (BOOL)isEqual:(RMValueType *)object
+      {
+        if (self == object) {
+          return YES;
+        } else if (self == nil || object == nil || ![object isKindOfClass:[self class]]) {
+          return NO;
+        }
+        return
+          _doesUserLike == object->_doesUserLike &&
+          (_identifier == object->_identifier ? YES : [_identifier isEqual:object->_identifier]);
+      }
+
+      @end
+
+      """
+    And the file "project/values/RMValueTypeBuilder.h" should contain:
+      """
+      #import <Foundation/Foundation.h>
+
+      @class RMValueType;
+
+      @interface RMValueTypeBuilder : NSObject
+
+      + (instancetype)valueType;
+
+      + (instancetype)valueTypeFromExistingValueType:(RMValueType *)existingValueType;
+
+      - (RMValueType *)build;
+
+      - (instancetype)withDoesUserLike:(BOOL)doesUserLike;
+
+      - (instancetype)withIdentifier:(NSString *)identifier;
+
+      @end
+
+      """
+    And the file "project/values/RMValueTypeBuilder.m" should contain:
+      """
+      #if  ! __has_feature(objc_arc)
+      #error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+      #endif
+
+      #import "RMValueType.h"
+      #import "RMValueTypeBuilder.h"
+
+      @implementation RMValueTypeBuilder
+      {
+        BOOL _doesUserLike;
+        NSString *_identifier;
+      }
+
+      + (instancetype)valueType
+      {
+        return [[RMValueTypeBuilder alloc] init];
+      }
+
+      + (instancetype)valueTypeFromExistingValueType:(RMValueType *)existingValueType
+      {
+        return [[[RMValueTypeBuilder valueType]
+                 withDoesUserLike:existingValueType.doesUserLike]
+                withIdentifier:existingValueType.identifier];
+      }
+
+      - (RMValueType *)build
+      {
+        return [[RMValueType alloc] initWithDoesUserLike:_doesUserLike identifier:_identifier];
+      }
+
+      - (instancetype)withDoesUserLike:(BOOL)doesUserLike
+      {
+        _doesUserLike = doesUserLike;
+        return self;
+      }
+
+      - (instancetype)withIdentifier:(NSString *)identifier
+      {
+        _identifier = [identifier copy];
+        return self;
+      }
+
+      @end
+      """
+
+  @announce
+  Scenario: Prevent files from containing includes()/excludes()
+    Given a file named "project/values/RMValueType.value" with:
+      """
+      # Simple file
+      RMValueType includes(RMBuilder) {
+        BOOL doesUserLike
+        NSString* identifier
+      }
+      """
+    And a file named "project/.valueObjectConfig" with:
+      """
+      { }
+      """
+    When I run `../../bin/generate project --prohibit-embedded-includes`
+    Then the file "project/values/RMValueType.h" should not exist

--- a/src/__tests__/commandline-test.ts
+++ b/src/__tests__/commandline-test.ts
@@ -40,7 +40,7 @@ describe('CommandLine', function() {
         dryRun: false,
         includes:[],
         excludes:[],
-        prohibitEmbeddedIncludes:false,
+        prohibitPluginDirectives:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -60,7 +60,7 @@ describe('CommandLine', function() {
         dryRun:false,
         includes:[],
         excludes:[],
-        prohibitEmbeddedIncludes:false,
+        prohibitPluginDirectives:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -80,7 +80,7 @@ describe('CommandLine', function() {
         dryRun:false,
         includes:[],
         excludes:[],
-        prohibitEmbeddedIncludes:false,
+        prohibitPluginDirectives:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -100,7 +100,7 @@ describe('CommandLine', function() {
         dryRun:false,
         includes:[],
         excludes:[],
-        prohibitEmbeddedIncludes:false,
+        prohibitPluginDirectives:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -120,7 +120,7 @@ describe('CommandLine', function() {
         dryRun:true,
         includes:[],
         excludes:[],
-        prohibitEmbeddedIncludes:false,
+        prohibitPluginDirectives:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -140,7 +140,7 @@ describe('CommandLine', function() {
         dryRun:false,
         includes:[],
         excludes:[],
-        prohibitEmbeddedIncludes:false,
+        prohibitPluginDirectives:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -160,7 +160,7 @@ describe('CommandLine', function() {
         dryRun: false,
         includes:[],
         excludes:[],
-        prohibitEmbeddedIncludes:false,
+        prohibitPluginDirectives:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -180,7 +180,7 @@ describe('CommandLine', function() {
         dryRun: false,
         includes:[],
         excludes:[],
-        prohibitEmbeddedIncludes:false,
+        prohibitPluginDirectives:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -200,14 +200,14 @@ describe('CommandLine', function() {
         dryRun: false,
         includes:['PluginOne', 'PluginTwo'],
         excludes:['PluginThree'],
-        prohibitEmbeddedIncludes:false,
+        prohibitPluginDirectives:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
     });
 
-    it('sets flag to prohibit embedded includes if passed flag', function() {
-      const args:string[] = ['project/to/generate', '--prohibit-embedded-includes'];
+    it('sets flag to prohibit embedded plugin includes/excludes if passed flag', function() {
+      const args:string[] = ['project/to/generate', '--prohibit-plugin-directives'];
       const parsedArgs:Maybe.Maybe<CommandLine.Arguments> = CommandLine.parseArgs(args);
 
       const expectedResult = Maybe.Just<CommandLine.Arguments>({
@@ -220,7 +220,7 @@ describe('CommandLine', function() {
         dryRun: false,
         includes:[],
         excludes:[],
-        prohibitEmbeddedIncludes:true,
+        prohibitPluginDirectives:true,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);

--- a/src/__tests__/commandline-test.ts
+++ b/src/__tests__/commandline-test.ts
@@ -37,7 +37,10 @@ describe('CommandLine', function() {
         objectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
         minimalLevel:10,
-        dryRun: false
+        dryRun: false,
+        includes:[],
+        excludes:[],
+        prohibitEmbeddedIncludes:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -54,7 +57,10 @@ describe('CommandLine', function() {
         objectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
         minimalLevel:1,
-        dryRun:false
+        dryRun:false,
+        includes:[],
+        excludes:[],
+        prohibitEmbeddedIncludes:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -71,7 +77,10 @@ describe('CommandLine', function() {
         objectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error, Logging.LoggingType.performance),
         minimalLevel:10,
-        dryRun:false
+        dryRun:false,
+        includes:[],
+        excludes:[],
+        prohibitEmbeddedIncludes:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -88,7 +97,10 @@ describe('CommandLine', function() {
         objectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error, Logging.LoggingType.debug),
         minimalLevel:10,
-        dryRun:false
+        dryRun:false,
+        includes:[],
+        excludes:[],
+        prohibitEmbeddedIncludes:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -105,7 +117,10 @@ describe('CommandLine', function() {
         objectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
         minimalLevel:10,
-        dryRun:true
+        dryRun:true,
+        includes:[],
+        excludes:[],
+        prohibitEmbeddedIncludes:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -122,7 +137,10 @@ describe('CommandLine', function() {
         objectConfigPath:undefined,
         interestedLoggingTypes:List.of<Logging.LoggingType>(),
         minimalLevel:10,
-        dryRun:false
+        dryRun:false,
+        includes:[],
+        excludes:[],
+        prohibitEmbeddedIncludes:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -139,7 +157,10 @@ describe('CommandLine', function() {
         objectConfigPath:undefined,
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
         minimalLevel:10,
-        dryRun: false
+        dryRun: false,
+        includes:[],
+        excludes:[],
+        prohibitEmbeddedIncludes:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -156,7 +177,50 @@ describe('CommandLine', function() {
         objectConfigPath:'path/to/objectConfig',
         interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
         minimalLevel:10,
-        dryRun: false
+        dryRun: false,
+        includes:[],
+        excludes:[],
+        prohibitEmbeddedIncludes:false,
+      });
+
+      expect(parsedArgs).toEqualJSON(expectedResult);
+    });
+
+    it('includes a list of includes and excludes if specified', function() {
+      const args:string[] = ['project/to/generate', '--include=PluginOne', '--include=PluginTwo', '--exclude=PluginThree'];
+      const parsedArgs:Maybe.Maybe<CommandLine.Arguments> = CommandLine.parseArgs(args);
+
+      const expectedResult = Maybe.Just<CommandLine.Arguments>({
+        givenPath:'project/to/generate',
+        adtConfigPath:undefined,
+        valueObjectConfigPath:undefined,
+        objectConfigPath:undefined,
+        interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
+        minimalLevel:10,
+        dryRun: false,
+        includes:['PluginOne', 'PluginTwo'],
+        excludes:['PluginThree'],
+        prohibitEmbeddedIncludes:false,
+      });
+
+      expect(parsedArgs).toEqualJSON(expectedResult);
+    });
+
+    it('sets flag to prohibit embedded includes if passed flag', function() {
+      const args:string[] = ['project/to/generate', '--prohibit-embedded-includes'];
+      const parsedArgs:Maybe.Maybe<CommandLine.Arguments> = CommandLine.parseArgs(args);
+
+      const expectedResult = Maybe.Just<CommandLine.Arguments>({
+        givenPath:'project/to/generate',
+        adtConfigPath:undefined,
+        valueObjectConfigPath:undefined,
+        objectConfigPath:undefined,
+        interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
+        minimalLevel:10,
+        dryRun: false,
+        includes:[],
+        excludes:[],
+        prohibitEmbeddedIncludes:true,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);

--- a/src/algebraic-types.ts
+++ b/src/algebraic-types.ts
@@ -36,7 +36,7 @@ interface AlgebraicTypeCreationContext {
   diagnosticIgnores:List.List<string>;
   plugins:List.List<AlgebraicType.Plugin>;
   defaultIncludes:List.List<string>;
-  prohibitEmbeddedIncludes:Boolean;
+  prohibitPluginDirectives:Boolean;
 }
 
 interface PathAndTypeInfo {
@@ -96,8 +96,8 @@ function processAlgebraicTypeCreationRequest(future:Promise.Future<Either.Either
   return Promise.map(function(creationContextEither:Either.Either<Error.Error[], AlgebraicTypeCreationContext>) {
     return Logging.munit(Either.mbind(function(pathAndTypeInfo:PathAndTypeInfo) {
       return Either.mbind(function(creationContext:AlgebraicTypeCreationContext) {
-        if (creationContext.prohibitEmbeddedIncludes && (pathAndTypeInfo.typeInformation.includes.length > 0 || pathAndTypeInfo.typeInformation.excludes.length > 0)) {
-          return Either.Left<Error.Error[], FileWriter.FileWriteRequest>([{reason:'includes()/excludes() is disallowed with the --prohibit-embedded-includes flag'}])
+        if (creationContext.prohibitPluginDirectives && (pathAndTypeInfo.typeInformation.includes.length > 0 || pathAndTypeInfo.typeInformation.excludes.length > 0)) {
+          return Either.Left<Error.Error[], FileWriter.FileWriteRequest>([{reason:'includes()/excludes() is disallowed with the --prohibit-plugin-directives flag'}])
         } else {
           const request:AlgebraicTypeCreation.Request = {
             diagnosticIgnores:creationContext.diagnosticIgnores,
@@ -151,7 +151,7 @@ function getAlgebraicTypeCreationContext(currentWorkingDirectory:File.AbsoluteFi
               diagnosticIgnores:configuration.diagnosticIgnores,
               plugins:plugins,
               defaultIncludes:List.fromArray<string>(PluginInclusionUtils.includesContainingDefaultIncludes(parsedArgs.includes, parsedArgs.excludes, configuration.defaultIncludes)),
-              prohibitEmbeddedIncludes:parsedArgs.prohibitEmbeddedIncludes,
+              prohibitPluginDirectives:parsedArgs.prohibitPluginDirectives,
             };
           }, pluginsEither);
         },

--- a/src/algebraic-types.ts
+++ b/src/algebraic-types.ts
@@ -36,6 +36,7 @@ interface AlgebraicTypeCreationContext {
   diagnosticIgnores:List.List<string>;
   plugins:List.List<AlgebraicType.Plugin>;
   defaultIncludes:List.List<string>;
+  prohibitEmbeddedIncludes:Boolean;
 }
 
 interface PathAndTypeInfo {
@@ -95,15 +96,19 @@ function processAlgebraicTypeCreationRequest(future:Promise.Future<Either.Either
   return Promise.map(function(creationContextEither:Either.Either<Error.Error[], AlgebraicTypeCreationContext>) {
     return Logging.munit(Either.mbind(function(pathAndTypeInfo:PathAndTypeInfo) {
       return Either.mbind(function(creationContext:AlgebraicTypeCreationContext) {
-        const request:AlgebraicTypeCreation.Request = {
-          diagnosticIgnores:creationContext.diagnosticIgnores,
-          baseClassLibraryName:creationContext.baseClassLibraryName,
-          baseClassName:creationContext.baseClassName,
-          path:pathAndTypeInfo.path,
-          typeInformation:typeInformationContainingDefaultIncludes(pathAndTypeInfo.typeInformation, creationContext.defaultIncludes)
-        };
+        if (creationContext.prohibitEmbeddedIncludes && (pathAndTypeInfo.typeInformation.includes.length > 0 || pathAndTypeInfo.typeInformation.excludes.length > 0)) {
+          return Either.Left<Error.Error[], FileWriter.FileWriteRequest>([{reason:'includes()/excludes() is disallowed with the --prohibit-embedded-includes flag'}])
+        } else {
+          const request:AlgebraicTypeCreation.Request = {
+            diagnosticIgnores:creationContext.diagnosticIgnores,
+            baseClassLibraryName:creationContext.baseClassLibraryName,
+            baseClassName:creationContext.baseClassName,
+            path:pathAndTypeInfo.path,
+            typeInformation:typeInformationContainingDefaultIncludes(pathAndTypeInfo.typeInformation, creationContext.defaultIncludes)
+          };
 
-        return AlgebraicTypeCreation.fileWriteRequest(request, creationContext.plugins);
+          return AlgebraicTypeCreation.fileWriteRequest(request, creationContext.plugins);
+        }
       }, creationContextEither);
     }, either));
   }, future);
@@ -123,7 +128,7 @@ function pluginsFromPluginConfigs(pluginConfigs:List.List<Configuration.PluginCo
   }, Either.Right<Error.Error[], List.List<AlgebraicType.Plugin>>(List.of<AlgebraicType.Plugin>()), pluginConfigs);
 }
 
-function getAlgebraicTypeCreationContext(currentWorkingDirectory:File.AbsoluteFilePath):Promise.Future<Either.Either<Error.Error[], AlgebraicTypeCreationContext>> {
+function getAlgebraicTypeCreationContext(currentWorkingDirectory:File.AbsoluteFilePath, parsedArgs:CommandLine.Arguments):Promise.Future<Either.Either<Error.Error[], AlgebraicTypeCreationContext>> {
   const findConfigFuture = FileFinder.findConfig('.algebraicTypeConfig', currentWorkingDirectory);
   return Promise.mbind(function(maybePath:Maybe.Maybe<File.AbsoluteFilePath>):Promise.Future<Either.Either<Error.Error[], AlgebraicTypeCreationContext>> {
     const configurationContext:Configuration.ConfigurationContext = {
@@ -145,7 +150,8 @@ function getAlgebraicTypeCreationContext(currentWorkingDirectory:File.AbsoluteFi
               baseClassLibraryName:configuration.baseClassLibraryName,
               diagnosticIgnores:configuration.diagnosticIgnores,
               plugins:plugins,
-              defaultIncludes:configuration.defaultIncludes
+              defaultIncludes:List.fromArray<string>(PluginInclusionUtils.includesContainingDefaultIncludes(parsedArgs.includes, parsedArgs.excludes, configuration.defaultIncludes)),
+              prohibitEmbeddedIncludes:parsedArgs.prohibitEmbeddedIncludes,
             };
           }, pluginsEither);
         },
@@ -156,7 +162,7 @@ function getAlgebraicTypeCreationContext(currentWorkingDirectory:File.AbsoluteFi
 
 export function generate(directoryRunFrom:string, parsedArgs:CommandLine.Arguments):Promise.Future<WriteFileUtils.ConsoleOutputResults> {
     const requestedPath:File.AbsoluteFilePath = PathUtils.getAbsolutePathFromDirectoryAndAbsoluteOrRelativePath(File.getAbsoluteFilePath(directoryRunFrom), parsedArgs.givenPath);
-    const algebraicTypeCreationContextFuture = getAlgebraicTypeCreationContext(requestedPath);
+    const algebraicTypeCreationContextFuture = getAlgebraicTypeCreationContext(requestedPath, parsedArgs);
 
     const readFileSequence = ReadFileUtils.loggedSequenceThatReadsFiles(requestedPath, 'adtValue');
 

--- a/src/commandline.ts
+++ b/src/commandline.ts
@@ -22,6 +22,9 @@ export interface Arguments {
   interestedLoggingTypes:List.List<Logging.LoggingType>;
   minimalLevel:number;
   dryRun:boolean;
+  includes:string[];
+  excludes:string[];
+  prohibitEmbeddedIncludes:boolean;
 }
 
 const VERBOSE_FLAG:string = 'verbose';
@@ -29,6 +32,9 @@ const PERF_LOGGING_FLAG:string = 'perf-log';
 const DEBUG_LOGGING_FLAG:string = 'debug';
 const SILENT_LOGGING_FLAG:string = 'silent';
 const DRY_RUN_FLAG:string = 'dry-run';
+const INCLUDE:string = 'include';
+const EXCLUDE:string = 'exclude';
+const PROHIBIT_INCLUDES_FLAG:string = 'prohibit-embedded-includes';
 
 const ADT_CONFIG_PATH:string = 'adt-config-path';
 const VALUE_OBJECT_CONFIG_PATH:string = 'value-object-config-path';
@@ -46,10 +52,20 @@ function interestedTypesForArgs(args:minimist.ParsedArgs):List.List<Logging.Logg
   }
 }
 
+function sanitizeArrayArg(arg:any): string[] {
+  if (typeof arg == "string") {
+    return [arg];
+  } else if (Array.isArray(arg)) {
+    return arg;
+  } else {
+    return [];
+  }
+}
+
 export function parseArgs(args:string[]):Maybe.Maybe<Arguments> {
   const opts = {
-    boolean:[VERBOSE_FLAG, PERF_LOGGING_FLAG, DEBUG_LOGGING_FLAG, SILENT_LOGGING_FLAG, DRY_RUN_FLAG],
-    string:[ADT_CONFIG_PATH, VALUE_OBJECT_CONFIG_PATH, OBJECT_CONFIG_PATH]
+    boolean:[VERBOSE_FLAG, PERF_LOGGING_FLAG, DEBUG_LOGGING_FLAG, SILENT_LOGGING_FLAG, DRY_RUN_FLAG, PROHIBIT_INCLUDES_FLAG],
+    string:[ADT_CONFIG_PATH, VALUE_OBJECT_CONFIG_PATH, OBJECT_CONFIG_PATH, INCLUDE, EXCLUDE],
   };
   const parsedArgs = minimist(args, opts);
   if (parsedArgs._.length === 0) {
@@ -62,7 +78,10 @@ export function parseArgs(args:string[]):Maybe.Maybe<Arguments> {
       objectConfigPath:parsedArgs[OBJECT_CONFIG_PATH],
       interestedLoggingTypes:interestedTypesForArgs(parsedArgs),
       minimalLevel:parsedArgs[VERBOSE_FLAG] ? 1 : 10,
-      dryRun:parsedArgs[DRY_RUN_FLAG]
+      dryRun:parsedArgs[DRY_RUN_FLAG],
+      includes:sanitizeArrayArg(parsedArgs[INCLUDE]),
+      excludes:sanitizeArrayArg(parsedArgs[EXCLUDE]),
+      prohibitEmbeddedIncludes:parsedArgs[PROHIBIT_INCLUDES_FLAG],
     });
   }
 }

--- a/src/commandline.ts
+++ b/src/commandline.ts
@@ -24,7 +24,7 @@ export interface Arguments {
   dryRun:boolean;
   includes:string[];
   excludes:string[];
-  prohibitEmbeddedIncludes:boolean;
+  prohibitPluginDirectives:boolean;
 }
 
 const VERBOSE_FLAG:string = 'verbose';
@@ -34,7 +34,7 @@ const SILENT_LOGGING_FLAG:string = 'silent';
 const DRY_RUN_FLAG:string = 'dry-run';
 const INCLUDE:string = 'include';
 const EXCLUDE:string = 'exclude';
-const PROHIBIT_INCLUDES_FLAG:string = 'prohibit-embedded-includes';
+const PROHIBIT_PLUGIN_DIRECTIVES_FLAG:string = 'prohibit-plugin-directives';
 
 const ADT_CONFIG_PATH:string = 'adt-config-path';
 const VALUE_OBJECT_CONFIG_PATH:string = 'value-object-config-path';
@@ -64,7 +64,7 @@ function sanitizeArrayArg(arg:any): string[] {
 
 export function parseArgs(args:string[]):Maybe.Maybe<Arguments> {
   const opts = {
-    boolean:[VERBOSE_FLAG, PERF_LOGGING_FLAG, DEBUG_LOGGING_FLAG, SILENT_LOGGING_FLAG, DRY_RUN_FLAG, PROHIBIT_INCLUDES_FLAG],
+    boolean:[VERBOSE_FLAG, PERF_LOGGING_FLAG, DEBUG_LOGGING_FLAG, SILENT_LOGGING_FLAG, DRY_RUN_FLAG, PROHIBIT_PLUGIN_DIRECTIVES_FLAG],
     string:[ADT_CONFIG_PATH, VALUE_OBJECT_CONFIG_PATH, OBJECT_CONFIG_PATH, INCLUDE, EXCLUDE],
   };
   const parsedArgs = minimist(args, opts);
@@ -81,7 +81,7 @@ export function parseArgs(args:string[]):Maybe.Maybe<Arguments> {
       dryRun:parsedArgs[DRY_RUN_FLAG],
       includes:sanitizeArrayArg(parsedArgs[INCLUDE]),
       excludes:sanitizeArrayArg(parsedArgs[EXCLUDE]),
-      prohibitEmbeddedIncludes:parsedArgs[PROHIBIT_INCLUDES_FLAG],
+      prohibitPluginDirectives:parsedArgs[PROHIBIT_PLUGIN_DIRECTIVES_FLAG],
     });
   }
 }

--- a/src/object-specs.ts
+++ b/src/object-specs.ts
@@ -37,7 +37,7 @@ interface ObjectSpecCreationContext {
   diagnosticIgnores:List.List<string>;
   plugins:List.List<ObjectSpec.Plugin>;
   defaultIncludes:List.List<string>;
-  prohibitEmbeddedIncludes:Boolean;
+  prohibitPluginDirectives:Boolean;
 }
 
 interface PathAndTypeInfo {
@@ -75,8 +75,8 @@ function processObjectSpecCreationRequest(future:Promise.Future<Either.Either<Er
   return Promise.map(function(creationContextEither:Either.Either<Error.Error[], ObjectSpecCreationContext>) {
     return Logging.munit(Either.mbind(function(pathAndTypeInfo:PathAndTypeInfo) {
       return Either.mbind(function(creationContext:ObjectSpecCreationContext) {
-        if (creationContext.prohibitEmbeddedIncludes && (pathAndTypeInfo.typeInformation.includes.length > 0 || pathAndTypeInfo.typeInformation.excludes.length > 0)) {
-          return Either.Left<Error.Error[], FileWriter.FileWriteRequest>([{reason:'includes()/excludes() is disallowed with the --prohibit-embedded-includes flag'}])
+        if (creationContext.prohibitPluginDirectives && (pathAndTypeInfo.typeInformation.includes.length > 0 || pathAndTypeInfo.typeInformation.excludes.length > 0)) {
+          return Either.Left<Error.Error[], FileWriter.FileWriteRequest>([{reason:'includes()/excludes() is disallowed with the --prohibit-plugin-directives flag'}])
         } else {
           const request:ObjectSpecCreation.Request = {
             diagnosticIgnores:creationContext.diagnosticIgnores,
@@ -121,7 +121,7 @@ function getObjectSpecCreationContext(valueObjectConfigPathFuture:Promise.Future
             diagnosticIgnores:configuration.diagnosticIgnores,
             plugins:plugins,
             defaultIncludes:List.fromArray<string>(PluginInclusionUtils.includesContainingDefaultIncludes(parsedArgs.includes, parsedArgs.excludes, configuration.defaultIncludes)),
-            prohibitEmbeddedIncludes:parsedArgs.prohibitEmbeddedIncludes,
+            prohibitPluginDirectives:parsedArgs.prohibitPluginDirectives,
           };
         }, pluginsEither);
       }, either);


### PR DESCRIPTION
Added the --includes, --excludes and --prohibited-embedded-includes parameters. The --includes and --excludes parameters allow you to pass plugin names to run (or not run) on the command line and not in the remodel file itself. They are combined with the file's includes and excludes directives.

If the --prohibit-embedded-includes parameter is passed, this will force an error if the remodel file being parsed has an includes() or excludes() parameter in it. This is to help force the fact that we should be passing our includes on the command line.

This is all to support internal buck/remodel integration.

If you ignore these parameters and never use them, you still get the original behavior.