### PR TITLE
[RMCoding] Support for multiple legacyCodingKeys on a single attribute

### DIFF
--- a/features/coding.feature
+++ b/features/coding.feature
@@ -94,6 +94,7 @@ Feature: Outputting Value Objects With Coded Values
         %codingLegacyKey name=old_like_count
         NSInteger likeCount
         %codingLegacyKey name=old_number_of_ratings
+        %codingLegacyKey name=even_older_number_of_ratings
         NSUInteger numberOfRatings
       }
       """
@@ -122,6 +123,9 @@ Feature: Outputting Value Objects With Coded Values
           _numberOfRatings = [aDecoder decodeIntegerForKey:kNumberOfRatingsKey];
           if (_numberOfRatings == 0) {
             _numberOfRatings = [aDecoder decodeIntegerForKey:@"old_number_of_ratings"];
+          }
+          if (_numberOfRatings == 0) {
+            _numberOfRatings = [aDecoder decodeIntegerForKey:@"even_older_number_of_ratings"];
           }
         }
         return self;

--- a/src/__tests__/plugins/coding-test.ts
+++ b/src/__tests__/plugins/coding-test.ts
@@ -655,7 +655,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'doesUserLike',
         valueAccessor: '_doesUserLike',
         constantName: 'kDoesUserLikeKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'BOOL',
           reference: 'BOOL'
@@ -672,7 +672,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'foo',
         valueAccessor: '_foo',
         constantName: 'kFooKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'id',
           reference: 'id'
@@ -689,7 +689,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'name',
         valueAccessor: '_name',
         constantName: 'kNameKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'NSObject',
           reference: 'NSObject *'
@@ -706,7 +706,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'age',
         valueAccessor: '_age',
         constantName: 'kAgeKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'NSInteger',
           reference: 'NSInteger'
@@ -723,7 +723,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'age',
         valueAccessor: '_age',
         constantName: 'kAgeKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'NSUInteger',
           reference: 'NSUInteger'
@@ -740,7 +740,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'callbackMethod',
         valueAccessor: '_callbackMethod',
         constantName: 'kCallbackMethodKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'SEL',
           reference: 'SEL'
@@ -759,7 +759,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'doesUserLike',
         valueAccessor: '_doesUserLike',
         constantName: 'kDoesUserLikeKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'BOOL',
           reference: 'BOOL'
@@ -776,7 +776,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'name',
         valueAccessor: '_name',
         constantName: 'kNameKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'NSObject',
           reference: 'NSObject *'
@@ -793,7 +793,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'age',
         valueAccessor: '_age',
         constantName: 'kAgeKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'NSInteger',
           reference: 'NSInteger'
@@ -810,7 +810,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'age',
         valueAccessor: '_age',
         constantName: 'kAgeKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'NSUInteger',
           reference: 'NSUInteger'
@@ -827,7 +827,7 @@ describe('ObjectSpecPlugins.Coding', function() {
         name: 'callbackMethod',
         valueAccessor: '_callbackMethod',
         constantName: 'kCallbackMethodKey',
-        legacyKeyName: '',
+        legacyKeyNames: [],
         type: {
           name: 'SEL',
           reference: 'SEL'


### PR DESCRIPTION
This extends on #76 to allow multiple legacy keys on a single property.

Example:

```
test includes(RMCoding) {
  %codingLegacyKey name=oldCodingKey
  %codingLegacyKey name=evenOlderCodingKey
  NSString *someString;
}
```

results in this `initWithCoder:` implementation:

```
_someString = [aDecoder decodeObjectForKey:kSomeStringKey];
if (_someString == nil) {
  _someString = [aDecoder decodeObjectForKey:@"oldCodingKey"];
}
if (_someString == nil) {
  _someString = [aDecoder decodeObjectForKey:@"evenOlderCodingKey"];
}
```
