### PR TITLE
Add new RMRestrictSubclassing plugin

### DIFF
--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -85,6 +85,9 @@ Feature: Outputting Value Objects With A Custom Plugin
             return {
               value: null
             };
+          },
+          subclassingRestricted: function (valueType) {
+            return false;
           }
         };
       }

--- a/features/subclassing-restricted.feature
+++ b/features/subclassing-restricted.feature
@@ -1,0 +1,54 @@
+Feature: Outputting Value Objects
+
+  @announce
+  Scenario: Generating a class that prohibits subclassing
+    Given a file named "project/values/RMFoo.value" with:
+      """
+      # some class comment
+      RMFoo includes(RMSubclassingRestricted) {
+        NSString* x
+      }
+      """
+    And a file named "project/.valueObjectConfig" with:
+      """
+      { }
+      """
+    When I run `../../bin/generate project`
+    And the file "project/values/RMFoo.h" should contain:
+      """
+      #import <Foundation/Foundation.h>
+
+      /**
+       * some class comment
+       */
+      __attribute__((objc_subclassing_restricted)) 
+      @interface RMFoo : NSObject <NSCopying>
+
+      @property (nonatomic, readonly, copy) NSString *x;
+      """
+
+  @announce
+  Scenario: Generating a class that allows subclassing
+    Given a file named "project/values/RMFoo.value" with:
+      """
+      # some class comment
+      RMFoo excludes(RMSubclassingRestricted) {
+        NSString* x
+      }
+      """
+    And a file named "project/.valueObjectConfig" with:
+      """
+      { }
+      """
+    When I run `../../bin/generate project`
+    And the file "project/values/RMFoo.h" should contain:
+      """
+      #import <Foundation/Foundation.h>
+
+      /**
+       * some class comment
+       */
+      @interface RMFoo : NSObject <NSCopying>
+
+      @property (nonatomic, readonly, copy) NSString *x;
+      """

--- a/src/__tests__/objc-renderer-test.ts
+++ b/src/__tests__/objc-renderer-test.ts
@@ -215,7 +215,8 @@ describe('ObjCRenderer', function() {
                 name: 'NSCoding'
               }
             ],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -426,7 +427,8 @@ describe('ObjCRenderer', function() {
                 name: 'NSCoding'
               }
             ],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -632,7 +634,8 @@ describe('ObjCRenderer', function() {
                 name: 'NSCoding'
               }
             ],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -793,7 +796,8 @@ describe('ObjCRenderer', function() {
             ],
             internalProperties:[],
             implementedProtocols: [],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -907,7 +911,8 @@ describe('ObjCRenderer', function() {
             properties: [],
             internalProperties:[],
             implementedProtocols: [],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -983,7 +988,8 @@ describe('ObjCRenderer', function() {
             ],
             internalProperties:[],
             implementedProtocols: [],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -1093,7 +1099,8 @@ describe('ObjCRenderer', function() {
             properties: [],
             internalProperties:[],
             implementedProtocols: [],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -1166,7 +1173,8 @@ describe('ObjCRenderer', function() {
           properties: [],
           internalProperties:[],
           implementedProtocols: [],
-          nullability: ObjC.ClassNullability.default
+          nullability: ObjC.ClassNullability.default,
+          subclassingRestricted: false,
         }
         ],
         structs: [],
@@ -1264,7 +1272,8 @@ describe('ObjCRenderer', function() {
           properties: [],
           internalProperties:[],
           implementedProtocols: [],
-          nullability: ObjC.ClassNullability.default
+          nullability: ObjC.ClassNullability.default,
+          subclassingRestricted: false,
         }
         ],
         structs: [],
@@ -1330,7 +1339,8 @@ describe('ObjCRenderer', function() {
             properties: [],
             internalProperties:[],
             implementedProtocols: [],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -1410,7 +1420,8 @@ describe('ObjCRenderer', function() {
               name: 'NSCopying'
             }
           ],
-          nullability: ObjC.ClassNullability.default
+          nullability: ObjC.ClassNullability.default,
+          subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -1495,7 +1506,8 @@ describe('ObjCRenderer', function() {
               name: 'NSCopying'
             }
           ],
-          nullability: ObjC.ClassNullability.default
+          nullability: ObjC.ClassNullability.default,
+          subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -1588,7 +1600,8 @@ describe('ObjCRenderer', function() {
             ],
             internalProperties:[],
             implementedProtocols: [],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -1760,7 +1773,8 @@ describe('ObjCRenderer', function() {
             ],
             internalProperties:[],
             implementedProtocols:[],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -1872,7 +1886,8 @@ describe('ObjCRenderer', function() {
             ],
             internalProperties:[],
             implementedProtocols:[],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -2082,7 +2097,8 @@ describe('ObjCRenderer', function() {
               }
             ],
             implementedProtocols: [],
-            nullability: ObjC.ClassNullability.default
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
           }
         ],
         structs: [],
@@ -2246,7 +2262,8 @@ describe('ObjCRenderer', function() {
           ],
           internalProperties:[],
           implementedProtocols: [],
-          nullability: ObjC.ClassNullability.default
+          nullability: ObjC.ClassNullability.default,
+          subclassingRestricted: false,
         }
         ],
         structs: [],
@@ -2355,7 +2372,8 @@ describe('ObjCRenderer', function() {
           properties: [],
           internalProperties:[],
           implementedProtocols: [],
-          nullability: ObjC.ClassNullability.default
+          nullability: ObjC.ClassNullability.default,
+          subclassingRestricted: false,
         }
         ],
         structs: [],
@@ -2431,7 +2449,8 @@ describe('ObjCRenderer', function() {
           properties: [],
           internalProperties:[],
           implementedProtocols: [],
-          nullability: ObjC.ClassNullability.default
+          nullability: ObjC.ClassNullability.default,
+          subclassingRestricted: false,
         }
         ],
         structs: [],
@@ -2646,7 +2665,8 @@ describe('ObjCRenderer', function() {
           properties: [],
           internalProperties:[],
           implementedProtocols: [],
-          nullability: ObjC.ClassNullability.default
+          nullability: ObjC.ClassNullability.default,
+          subclassingRestricted: false,
         }
         ],
         structs: [],
@@ -2705,7 +2725,8 @@ describe('ObjCRenderer', function() {
             }
           ],
           implementedProtocols: [],
-          nullability: ObjC.ClassNullability.default
+          nullability: ObjC.ClassNullability.default,
+          subclassingRestricted: false,
         }
         ],
         structs: [],

--- a/src/__tests__/plugins/builder-test.ts
+++ b/src/__tests__/plugins/builder-test.ts
@@ -140,7 +140,8 @@ describe('Plugins.Builder', function() {
               properties: [],
               internalProperties: [],
               implementedProtocols: [],
-              nullability: ObjC.ClassNullability.default
+              nullability: ObjC.ClassNullability.default,
+              subclassingRestricted: false,
             }
           ],
           structs: [],
@@ -270,7 +271,8 @@ describe('Plugins.Builder', function() {
               properties: [],
               internalProperties: [],
               implementedProtocols: [],
-              nullability: ObjC.ClassNullability.default
+              nullability: ObjC.ClassNullability.default,
+              subclassingRestricted: false,
             }
           ],
           structs: [],
@@ -561,7 +563,8 @@ describe('Plugins.Builder', function() {
                 }
               ],
               implementedProtocols: [],
-              nullability: ObjC.ClassNullability.default
+              nullability: ObjC.ClassNullability.default,
+              subclassingRestricted: false,
             }
           ],
           structs: [],
@@ -852,7 +855,8 @@ describe('Plugins.Builder', function() {
                 }
               ],
               implementedProtocols: [],
-              nullability: ObjC.ClassNullability.default
+              nullability: ObjC.ClassNullability.default,
+              subclassingRestricted: false,
             }
           ],
           structs: [],

--- a/src/__tests__/plugins/subclassing-restricted-test.ts
+++ b/src/__tests__/plugins/subclassing-restricted-test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+///<reference path='../../type-defs/jasmine.d.ts'/>
+///<reference path='../../type-defs/jasmine-test-additions.d.ts'/>
+
+import AlgebraicType = require('../../algebraic-type');
+import SubclassingRestricted = require('../../plugins/subclassing-restricted');
+import Maybe = require('../../maybe');
+import ObjC = require('../../objc');
+import ObjectSpec = require('../../object-spec');
+
+const ObjectSpecPlugin = SubclassingRestricted.createPlugin();
+const AlgebraicTypePlugin = SubclassingRestricted.createAlgebraicTypePlugin();
+
+describe('ObjectSpecPlugins.SubclassingRestricted', function() {
+  describe('#instanceMethods', function() {
+    it('generates class with subclassing restricted compiler annotation', function() {
+      const objectType:ObjectSpec.Type = {
+        annotations: {},
+        attributes: [],
+        comments: [],
+        typeLookups:[],
+        excludes: [],
+        includes: ['RMSubclassingRestricted'],
+        libraryName: Maybe.Nothing<string>(),
+        typeName: 'Foo'
+      };
+
+      const subclassingRestricted:boolean = ObjectSpecPlugin.subclassingRestricted(objectType);
+      expect(subclassingRestricted).toEqual(true);
+    });
+  });
+});
+
+describe('AlgebraicTypePlugins.SubclassingRestricted', function() {
+  describe('#instanceMethods', function() {
+    it('always generates unavailable init/new methods for ADTs', function() {
+      const algebraicType:AlgebraicType.Type = {
+        annotations: {},
+        name: 'Foo',
+        includes: ['RMSubclassingRestricted'],
+        typeLookups:[],
+        excludes: [],
+        libraryName: Maybe.Nothing<string>(),
+        comments: [],
+        subtypes: [
+          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
+          {
+            name: 'subtypeOne',
+            comments: [],
+            attributes: []
+          })
+        ],
+      };
+
+      const subclassingRestricted:boolean = AlgebraicTypePlugin.subclassingRestricted(algebraicType);
+      expect(subclassingRestricted).toEqual(true);
+    });
+  });
+});

--- a/src/__tests__/value-object-creation-test.ts
+++ b/src/__tests__/value-object-creation-test.ts
@@ -94,7 +94,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
 
       const objectType:ObjectSpec.Type = {
@@ -197,7 +200,8 @@ describe('ObjectSpecCreation', function() {
                   properties: [],
                   internalProperties:[],
                   implementedProtocols: [],
-                  nullability: ObjC.ClassNullability.default
+                  nullability: ObjC.ClassNullability.default,
+                  subclassingRestricted: false,
                 }
               ],
               structs: [],
@@ -231,7 +235,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
 
       const objectType:ObjectSpec.Type = {
@@ -345,7 +352,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
 
       const objectType:ObjectSpec.Type = {
@@ -473,7 +483,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
 
       const objectType:ObjectSpec.Type = {
@@ -620,7 +633,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
 
       const objectType:ObjectSpec.Type = {
@@ -743,7 +759,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
 
       const objectType:ObjectSpec.Type = {
@@ -824,7 +843,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
       const Plugin2:ObjectSpec.Plugin = {
         requiredIncludesToRun: [],
@@ -875,7 +897,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
 
       const objectType:ObjectSpec.Type = {
@@ -994,7 +1019,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
       const Plugin2:ObjectSpec.Plugin = {
         requiredIncludesToRun: [],
@@ -1065,7 +1093,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
 
       const objectType:ObjectSpec.Type = {
@@ -1230,7 +1261,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
       const Plugin2:ObjectSpec.Plugin = {
         requiredIncludesToRun: [],
@@ -1305,7 +1339,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
 
       const objectType:ObjectSpec.Type = {
@@ -1451,7 +1488,10 @@ describe('ObjectSpecCreation', function() {
         },
         nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
           return Maybe.Nothing<ObjC.ClassNullability>();
-        }
+        },
+        subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+          return false;
+        },
       };
 
       const objectType:ObjectSpec.Type = {

--- a/src/algebraic-type-creation.ts
+++ b/src/algebraic-type-creation.ts
@@ -95,6 +95,10 @@ function createAlgebraicTypeObjCPlugIn(plugin:AlgebraicType.Plugin) : AlgebraicT
     nullability: function(typeInformation:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return plugin.nullability(typeInformation);
     },
+
+    subclassingRestricted: function(typeInformation:AlgebraicType.Type):boolean {
+      return plugin.subclassingRestricted(typeInformation);
+    },
   };
 }
 

--- a/src/algebraic-type.ts
+++ b/src/algebraic-type.ts
@@ -100,4 +100,5 @@ export interface Plugin {
   staticConstants: (algebraicType:Type) => ObjC.Constant[];
   validationErrors: (algebraicType:Type) => Error.Error[];
   nullability: (algebraicType:Type) => Maybe.Maybe<ObjC.ClassNullability>;
+  subclassingRestricted: (algebraicType:Type) => boolean;
 }

--- a/src/algebraic-types.ts
+++ b/src/algebraic-types.ts
@@ -64,6 +64,7 @@ const BASE_PLUGINS:List.List<string> = List.of(
   'description',
   'equality',
   'init-new-unavailable',
+  'subclassing-restricted',
   'use-cpp',
   'algebraic-type-function-matching',
   'algebraic-type-templated-matching'

--- a/src/objc-renderer.ts
+++ b/src/objc-renderer.ts
@@ -403,6 +403,7 @@ function headerClassSection(classInfo:ObjC.Class):string {
 
   const protocolsStr = protocolsString(classInfo.implementedProtocols);
 
+  const subclassingRestrictedStr = classInfo.subclassingRestricted ? '__attribute__((objc_subclassing_restricted)) \n' : '';
   const classSection = '@interface ' + classInfo.name + ' : ' + classInfo.baseClassName + protocolsStr;
 
   const internalPropertiesStr:string = classInfo.internalProperties.filter(headerNeedsToIncludeInternalProperty).reduce(buildInternalPropertiesContainingAccessIdentifiers, []).map(StringUtils.indent(2)).join('\n');
@@ -421,7 +422,7 @@ function headerClassSection(classInfo:ObjC.Class):string {
   const postfixClassMacrosStr:string = macros.map(toPostfixMacroString).join('\n');
   const postfixClassMacrosSection:string = postfixClassMacrosStr !== '' ? '\n\n' + postfixClassMacrosStr : '';
 
-  return prefixClassMacrosSection + classCommentsSection + classSection + '\n' + internalPropertiesSection + propertiesSection + classMethodsSection + instanceMethodsSection + '@end' + postfixClassMacrosSection;
+  return prefixClassMacrosSection + classCommentsSection + subclassingRestrictedStr + classSection + '\n' + internalPropertiesSection + propertiesSection + classMethodsSection + instanceMethodsSection + '@end' + postfixClassMacrosSection;
 }
 
 function toDeclarationString(forwardDeclaration:ObjC.ForwardDeclaration) {

--- a/src/objc.ts
+++ b/src/objc.ts
@@ -389,6 +389,7 @@ export interface Class {
   internalProperties:Property[];
   implementedProtocols:Protocol[];
   nullability:ClassNullability;
+  subclassingRestricted:boolean;
 }
 
 export interface Protocol {

--- a/src/object-spec-creation.ts
+++ b/src/object-spec-creation.ts
@@ -95,6 +95,10 @@ function createObjectSpecObjCPlugIn(plugin:ObjectSpec.Plugin) : ObjectSpecObjCPl
     nullability: function(typeInformation:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return plugin.nullability(typeInformation);
     },
+
+    subclassingRestricted: function(typeInformation:ObjectSpec.Type):boolean {
+      return plugin.subclassingRestricted(typeInformation);
+    },
   };
 }
 

--- a/src/object-spec-default-config.ts
+++ b/src/object-spec-default-config.ts
@@ -26,6 +26,7 @@ export const OBJECT_SPEC_DEFAULT_CONFIG = {
     'fetch-status',
     'immutable-properties',
     'init-new-unavailable',
+    'subclassing-restricted',
     'use-cpp'
   )
 };

--- a/src/object-spec.ts
+++ b/src/object-spec.ts
@@ -60,4 +60,5 @@ export interface Plugin {
   staticConstants: (objectType:Type) => ObjC.Constant[];
   validationErrors: (objectType:Type) => Error.Error[];
   nullability: (objectType:Type) => Maybe.Maybe<ObjC.ClassNullability>;
+  subclassingRestricted: (objectType:Type) => boolean;
 }

--- a/src/plugins/algebraic-type-function-matching.ts
+++ b/src/plugins/algebraic-type-function-matching.ts
@@ -103,6 +103,9 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/algebraic-type-initialization.ts
+++ b/src/plugins/algebraic-type-initialization.ts
@@ -326,6 +326,9 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/algebraic-type-templated-matching.ts
+++ b/src/plugins/algebraic-type-templated-matching.ts
@@ -197,6 +197,9 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/assert-nullability.ts
+++ b/src/plugins/assert-nullability.ts
@@ -110,7 +110,10 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+      return false;
+    },
   };
 }
 
@@ -166,6 +169,9 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/builder.ts
+++ b/src/plugins/builder.ts
@@ -303,7 +303,8 @@ function builderFileForValueType(objectType:ObjectSpec.Type):Code.File {
         properties: [],
         internalProperties:objectType.attributes.map(internalPropertyForAttribute),
         implementedProtocols: [],
-        nullability:ObjC.ClassNullability.default
+        nullability:ObjC.ClassNullability.default,
+        subclassingRestricted: false,
       }
     ],
     diagnosticIgnores:[],
@@ -364,6 +365,9 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/coding.ts
+++ b/src/plugins/coding.ts
@@ -449,7 +449,10 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+      return false;
+    },
   };
 }
 
@@ -629,6 +632,9 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/copying.ts
+++ b/src/plugins/copying.ts
@@ -98,7 +98,10 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+      return false;
+    },
   };
 }
 
@@ -156,6 +159,9 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/description.ts
+++ b/src/plugins/description.ts
@@ -347,7 +347,10 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+      return false;
+    },
   };
 }
 
@@ -438,6 +441,9 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/equality.ts
+++ b/src/plugins/equality.ts
@@ -1054,7 +1054,10 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+      return false;
+    },
   };
 }
 
@@ -1155,6 +1158,9 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/fetch-status.ts
+++ b/src/plugins/fetch-status.ts
@@ -137,6 +137,9 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/immutable-properties.ts
+++ b/src/plugins/immutable-properties.ts
@@ -300,6 +300,9 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/init-new-unavailable.ts
+++ b/src/plugins/init-new-unavailable.ts
@@ -121,7 +121,10 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+      return false;
+    },
   };
 }
 
@@ -175,6 +178,9 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/plugins/subclassing-restricted.ts
+++ b/src/plugins/subclassing-restricted.ts
@@ -8,12 +8,16 @@
  */
 
 import AlgebraicType = require('../algebraic-type');
+import AlgebraicTypeUtils = require('../algebraic-type-utils');
 import Code = require('../code');
 import Error = require('../error');
 import FileWriter = require('../file-writer');
+import FunctionUtils = require('../function-utils');
 import Maybe = require('../maybe');
 import ObjC = require('../objc');
+import ObjCTypeUtils = require('../objc-type-utils');
 import ObjectSpec = require('../object-spec');
+import ObjectSpecCodeUtils = require('../object-spec-code-utils');
 
 export function createPlugin():ObjectSpec.Plugin {
   return {
@@ -48,9 +52,7 @@ export function createPlugin():ObjectSpec.Plugin {
       return [];
     },
     imports: function(objectType:ObjectSpec.Type):ObjC.Import[] {
-      return [
-        { file: 'Foundation.h', isPublic: true, library: Maybe.Just('Foundation') },
-      ];
+      return [];
     },
     instanceMethods: function(objectType:ObjectSpec.Type):ObjC.Method[] {
       return [];
@@ -58,7 +60,7 @@ export function createPlugin():ObjectSpec.Plugin {
     properties: function(objectType:ObjectSpec.Type):ObjC.Property[] {
       return [];
     },
-    requiredIncludesToRun:['RMAssumeNonnull'],
+    requiredIncludesToRun:['RMSubclassingRestricted'],
     staticConstants: function(objectType:ObjectSpec.Type):ObjC.Constant[] {
       return [];
     },
@@ -66,10 +68,10 @@ export function createPlugin():ObjectSpec.Plugin {
       return [];
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
-      return Maybe.Just(ObjC.ClassNullability.assumeNonnull);
+      return Maybe.Nothing<ObjC.ClassNullability>();
     },
     subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
-      return false;
+      return true;
     },
   };
 }
@@ -107,9 +109,7 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
       return [];
     },
     imports: function(algebraicType:AlgebraicType.Type):ObjC.Import[] {
-      return [
-        { file: 'Foundation.h', isPublic: true, library: Maybe.Just('Foundation') },
-      ];
+      return [];
     },
     instanceMethods: function(algebraicType:AlgebraicType.Type):ObjC.Method[] {
       return [];
@@ -117,7 +117,7 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     internalProperties: function(algebraicType:AlgebraicType.Type):ObjC.Property[] {
       return [];
     },
-    requiredIncludesToRun: ['RMAssumeNonnull'],
+    requiredIncludesToRun: ['RMSubclassingRestricted'],
     staticConstants: function(algebraicType:AlgebraicType.Type):ObjC.Constant[] {
       return [];
     },
@@ -125,10 +125,10 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
       return [];
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
-      return Maybe.Just(ObjC.ClassNullability.assumeNonnull);
+      return Maybe.Nothing<ObjC.ClassNullability>();
     },
     subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
-      return false;
+      return true;
     },
   };
 }

--- a/src/plugins/use-cpp.ts
+++ b/src/plugins/use-cpp.ts
@@ -65,7 +65,10 @@ export function createPlugin():ObjectSpec.Plugin {
     },
     nullability: function(objectType:ObjectSpec.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(objectType:ObjectSpec.Type):boolean {
+      return false;
+    },
   };
 }
 
@@ -119,6 +122,9 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     },
     nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
       return Maybe.Nothing<ObjC.ClassNullability>();
-    }
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
   };
 }

--- a/src/value-object-default-config.ts
+++ b/src/value-object-default-config.ts
@@ -31,6 +31,7 @@ export const VALUE_OBJECT_DEFAULT_CONFIG = {
     'fetch-status',
     'immutable-properties',
     'init-new-unavailable',
+    'subclassing-restricted',
     'use-cpp'
   )
 };


### PR DESCRIPTION
This let's us prevent subclassing of generated remodel classes. Making it a default overall would have been the simpler route, but that would be a breaking change. Thus I went with the plugin approach.

If the plugin is included, generated classes will contain the following compiler annotation:

```
SomeClass includes(RMRestrictSubclassing) {
  NSString *x
}
```

```
__attribute__((objc_subclassing_restricted))
@interface SomeClass
@property (nonatomic, copy, readonly)  NSString *x;
@end
```

Which will prevent subclassing.