### PR TITLE
Rename FunctionMatching => VoidMatching to match other new matching plugin names

### DIFF
--- a/features/algebraic-type-matching.feature
+++ b/features/algebraic-type-matching.feature
@@ -4,7 +4,7 @@ Feature: Outputting expected Algebraic Type matching methods
   Scenario: Generating an algebraic type with a bool matcher
     Given a file named "project/values/SimpleADT.adtValue" with:
       """
-      SimpleADT includes(BoolMatching) excludes(FunctionMatching) {
+      SimpleADT includes(BoolMatching) excludes(VoidMatching) {
         subtypeA
         subtypeB
       }
@@ -68,7 +68,7 @@ Feature: Outputting expected Algebraic Type matching methods
   Scenario: Generating an algebraic type with a integer matcher
     Given a file named "project/values/SimpleADT.adtValue" with:
       """
-      SimpleADT includes(IntegerMatching) excludes(FunctionMatching) {
+      SimpleADT includes(IntegerMatching) excludes(VoidMatching) {
         subtypeA
         subtypeB
       }
@@ -132,7 +132,7 @@ Feature: Outputting expected Algebraic Type matching methods
   Scenario: Generating an algebraic type with a double matcher
     Given a file named "project/values/SimpleADT.adtValue" with:
       """
-      SimpleADT includes(DoubleMatching) excludes(FunctionMatching) {
+      SimpleADT includes(DoubleMatching) excludes(VoidMatching) {
         subtypeA
         subtypeB
       }

--- a/features/algebraic-type-templated-matching.feature
+++ b/features/algebraic-type-templated-matching.feature
@@ -21,7 +21,7 @@ Feature: Outputting Algebraic Types With Templated Matching
       """
       {
         "defaultIncludes": ["TemplatedMatching"],
-        "defaultExcludes": ["FunctionMatching"]
+        "defaultExcludes": ["VoidMatching"]
       }
       """
     When I run `../../bin/generate project`

--- a/src/algebraic-types.ts
+++ b/src/algebraic-types.ts
@@ -52,7 +52,7 @@ const BASE_INCLUDES:List.List<string> = List.of(
   'RMDescription',
   'RMEquality',
   'RMInitNewUnavailable',
-  'FunctionMatching'
+  'VoidMatching'
 );
 
 const BASE_PLUGINS:List.List<string> = List.of(

--- a/src/plugins/algebraic-type-matching-void.ts
+++ b/src/plugins/algebraic-type-matching-void.ts
@@ -62,7 +62,7 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
     internalProperties: function(algebraicType:AlgebraicType.Type):ObjC.Property[] {
       return [];
     },
-    requiredIncludesToRun: ['FunctionMatching'],
+    requiredIncludesToRun: ['VoidMatching'],
     staticConstants: function(algebraicType:AlgebraicType.Type):ObjC.Constant[] {
       return [];
     },


### PR DESCRIPTION
This makes more sense, now that we have `BoolMatching`, `DoubleMatching` and `IntegerMatching` plugins.

All unit & acceptance tests pass.