### PR TITLE
Avoid forward declaring the empty protocol

### DIFF
--- a/src/__tests__/objc-import-utils-test.ts
+++ b/src/__tests__/objc-import-utils-test.ts
@@ -14,6 +14,7 @@ import Maybe = require('../maybe');
 import ObjC = require('../objc');
 import ObjCImportUtils = require('../objc-import-utils');
 import ObjectGeneration = require('../object-generation');
+import ObjectSpec = require('../object-spec');
 
 describe('ObjCImportUtils', function() {
   describe('#importForTypeLookup', function() {
@@ -92,6 +93,29 @@ describe('ObjCImportUtils', function() {
       };
 
       expect(importValue).toEqualJSON(expectedImport);
+    });
+  });
+
+  describe('#shouldForwardProtocolDeclareAttribute', function() {
+    it('should return false for the empty protocol', function() {
+      const attributeType:ObjectSpec.AttributeType = {
+        fileTypeIsDefinedIn:Maybe.Nothing<string>(),
+        libraryTypeIsDefinedIn:Maybe.Nothing<string>(),
+        name:'NSArray',
+        reference: 'NSArray*',
+        underlyingType:Maybe.Just<string>('NSObject'),
+        conformingProtocol: Maybe.Just<string>('')
+      };
+      const attribute:ObjectSpec.Attribute = {
+          annotations: {},
+          comments: [],
+          name: 'someArray',
+          nullability:ObjC.Nullability.Inherited(),
+          type: attributeType
+      };
+
+      const shouldDeclare:boolean = ObjCImportUtils.shouldForwardProtocolDeclareAttribute(attribute);
+      expect(shouldDeclare).toEqual(false);
     });
   });
 });

--- a/src/objc-import-utils.ts
+++ b/src/objc-import-utils.ts
@@ -185,7 +185,7 @@ export function canForwardDeclareTypeForAttributeConsideringType(attribute:Objec
 export function shouldForwardProtocolDeclareAttribute(attribute:ObjectSpec.Attribute):boolean {
   return Maybe.match(
     function (protocol) {
-      return true;
+      return protocol !== '';
     },
     function () {
       return false;


### PR DESCRIPTION
Currently, declarations like "CKAction<>" result in an empty forward declaration which doesn't compile ("@protocol ;"). This diff changes the behavior in the presence of the empty protocol to be to not forward declare. This is still kind of a bandaid solution for handling C++ classes in Remodel, full support for C++ is a more involved feature.