### PR TITLE
Add support for rendering lightweight generics on ObjC classes

### DIFF
--- a/src/__tests__/objc-renderer-test.ts
+++ b/src/__tests__/objc-renderer-test.ts
@@ -43,6 +43,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [
               {
                 preprocessors:[],
@@ -280,6 +281,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [
               {
                 preprocessors:[],
@@ -490,6 +492,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'RMObjectSpecBase',
+            covariantTypes:[],
             classMethods: [
               {
                 preprocessors:[],
@@ -696,6 +699,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [],
             comments:[],
             instanceMethods: [
@@ -857,6 +861,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [],
             comments:[],
             instanceMethods: [
@@ -972,6 +977,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [],
             comments:[],
             instanceMethods: [
@@ -1094,6 +1100,7 @@ describe('ObjCRenderer', function() {
         classes:[
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [],
             comments:[],
             instanceMethods: [
@@ -1227,6 +1234,7 @@ describe('ObjCRenderer', function() {
         classes:[
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [],
             comments:[],
             instanceMethods: [],
@@ -1301,6 +1309,7 @@ describe('ObjCRenderer', function() {
         classes: [
         {
           baseClassName:'NSObject',
+          covariantTypes:[],
           classMethods: [],
           comments:[],
           instanceMethods: [],
@@ -1400,6 +1409,7 @@ describe('ObjCRenderer', function() {
         classes: [
         {
           baseClassName:'NSObject',
+          covariantTypes:[],
           classMethods: [],
           comments:[],
           instanceMethods: [],
@@ -1467,6 +1477,7 @@ describe('ObjCRenderer', function() {
         classes:[
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [],
             comments:[],
             instanceMethods: [],
@@ -1520,6 +1531,7 @@ describe('ObjCRenderer', function() {
         classes:[
         {
           baseClassName:'NSObject',
+          covariantTypes:[],
           classMethods: [],
           comments:[],
           instanceMethods: [],
@@ -1606,6 +1618,7 @@ describe('ObjCRenderer', function() {
         classes:[
         {
           baseClassName:'NSObject',
+          covariantTypes:[],
           classMethods: [],
           comments:[],
           instanceMethods: [],
@@ -1693,6 +1706,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [],
             comments:[],
             instanceMethods: [
@@ -1837,6 +1851,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [],
             comments:[],
             instanceMethods: [
@@ -1950,6 +1965,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [],
             comments:[],
             instanceMethods: [
@@ -2077,6 +2093,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [
               {
                 preprocessors:[],
@@ -2332,6 +2349,7 @@ describe('ObjCRenderer', function() {
         classes: [
         {
           baseClassName:'NSObject',
+          covariantTypes:[],
           classMethods: [],
           comments:[],
           instanceMethods: [
@@ -2467,6 +2485,7 @@ describe('ObjCRenderer', function() {
         classes: [
           {
             baseClassName:'NSObject',
+            covariantTypes:[],
             classMethods: [
               {
                 preprocessors:[
@@ -2756,6 +2775,7 @@ describe('ObjCRenderer', function() {
         classes: [
         {
           baseClassName:'NSObject',
+          covariantTypes:[],
           classMethods: [],
           comments:[],
           instanceMethods: [],
@@ -2833,6 +2853,7 @@ describe('ObjCRenderer', function() {
         classes: [
         {
           baseClassName:'NSObject',
+          covariantTypes:[],
           classMethods: [],
           comments:[],
           instanceMethods: [],
@@ -3049,6 +3070,7 @@ describe('ObjCRenderer', function() {
         classes: [
         {
           baseClassName:'NSObject',
+          covariantTypes:[],
           classMethods: [],
           comments:[],
           instanceMethods: [],
@@ -3088,6 +3110,7 @@ describe('ObjCRenderer', function() {
         classes: [
         {
           baseClassName:'NSObject',
+          covariantTypes:[],
           classMethods: [],
           comments:[],
           instanceMethods: [],

--- a/src/__tests__/objc-renderer-test.ts
+++ b/src/__tests__/objc-renderer-test.ts
@@ -2065,6 +2065,176 @@ describe('ObjCRenderer', function() {
       expect(renderedOutput).toEqualJSON(expectedOutput);
     });
 
+    it('includes covariantTypes in the header file', function() {
+      const fileToRender:Code.File = {
+        name: 'RMSomeValue',
+        type: Code.FileType.ObjectiveC(),
+        comments:[],
+        imports:[
+          {file:'RMSomething.h', isPublic:true, library:Maybe.Just('RMLibrary')},
+        ],
+        forwardDeclarations:[],
+        enumerations:[],
+        blockTypes:[],
+        staticConstants:[],
+        functions:[],
+        diagnosticIgnores:[],
+        classes: [
+          {
+            baseClassName:'NSObject',
+            covariantTypes:['ObjectType'],
+            classMethods: [
+              {
+                preprocessors:[],
+                belongsToProtocol:Maybe.Nothing<string>(),
+                code:[
+                  'return [[RMSomeValue alloc] init];'
+                ],
+                comments: [],
+                compilerAttributes:[],
+                keywords: [
+                  {
+                    name:'someClassMethodWithValue1',
+                    argument:Maybe.Just({
+                      name:'value1',
+                      modifiers: [],
+                      type: {
+                        name:'RMSomething',
+                        reference:'RMSomething *'
+                      }
+                    })
+                  },
+                  {
+                    name:'value2',
+                    argument:Maybe.Just({
+                      name:'value2',
+                      modifiers: [],
+                      type: {
+                        name:'RMSomething',
+                        reference:'RMSomething *'
+                      }
+                    })
+                  }
+                ],
+                returnType: {
+                  type:Maybe.Just({
+                    name:'ObjectType',
+                    reference:'ObjectType'
+                  }),
+                  modifiers:[ObjC.KeywordArgumentModifier.Nullable()]
+                }
+              }
+            ],
+            comments:[],
+            instanceMethods: [],
+            name:'RMSomeValue',
+            properties: [],
+            internalProperties:[],
+            implementedProtocols: [],
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
+          }
+        ],
+        structs:[],
+        namespaces:[],
+      };
+
+      const renderedOutput:Maybe.Maybe<string> = ObjCRenderer.renderHeader(fileToRender);
+
+      const expectedOutput:Maybe.Maybe<string> = Maybe.Just<string>(
+        '#import <RMLibrary/RMSomething.h>\n' +
+        '\n' +
+        '@interface RMSomeValue<__covariant ObjectType> : NSObject\n' +
+        '\n' +
+        '+ (nullable ObjectType)someClassMethodWithValue1:(RMSomething *)value1 value2:(RMSomething *)value2;\n' +
+        '\n' +
+        '@end\n' +
+        '\n'
+      );
+
+      expect(renderedOutput).toEqualJSON(expectedOutput);
+    });
+
+    it('supports multiple covariantTypes in the header file', function() {
+        
+      const fileToRender:Code.File = {
+        name: 'RMSomeValue',
+        type: Code.FileType.ObjectiveC(),
+        comments:[],
+        imports:[
+          {file:'RMSomething.h', isPublic:true, library:Maybe.Just('RMLibrary')},
+        ],
+        enumerations:[],
+        blockTypes:[],
+        staticConstants:[],
+        forwardDeclarations:[],
+        functions:[],
+        diagnosticIgnores:[],
+        classes: [
+          {
+            baseClassName:'NSObject',
+            classMethods: [],
+            comments:[],
+            covariantTypes:['KeyType', 'ValueType'],
+            instanceMethods: [
+              {
+                preprocessors:[],
+                belongsToProtocol:Maybe.Nothing<string>(),
+                code:[
+                  'return [[RMSomeValue alloc] init];'
+                ],
+                comments: [],
+                compilerAttributes:[],
+                keywords: [
+                  {
+                    name:'objectForKey',
+                    argument:Maybe.Just({
+                      name:'key',
+                      modifiers: [],
+                      type: {
+                        name:'KeyType',
+                        reference:'KeyType',
+                      }
+                    })
+                  }
+                ],
+                returnType: {
+                  type:Maybe.Just({
+                    name:'ValueType',
+                    reference:'ValueType'
+                  }),
+                  modifiers:[ObjC.KeywordArgumentModifier.Nullable()]
+                },
+              }
+            ],
+            name:'RMSomeValue',
+            properties: [],
+            internalProperties:[],
+            implementedProtocols: [],
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
+          }
+        ],
+        structs:[],
+        namespaces:[],
+      };
+
+      const renderedOutput:Maybe.Maybe<string> = ObjCRenderer.renderHeader(fileToRender);
+
+      const expectedOutput:Maybe.Maybe<string> = Maybe.Just<string>(
+        '#import <RMLibrary/RMSomething.h>\n' +
+        '\n' +
+        '@interface RMSomeValue<__covariant KeyType, __covariant ValueType> : NSObject\n' +
+        '\n' +
+        '- (nullable ValueType)objectForKey:(KeyType)key;\n' +
+        '\n' +
+        '@end\n' +
+        '\n'
+      );
+
+      expect(renderedOutput).toEqualJSON(expectedOutput);
+    });
+
   });
 
   describe('#renderImplementation', function() {
@@ -2821,6 +2991,187 @@ describe('ObjCRenderer', function() {
       expect(renderedOutput).toEqualJSON(expectedOutput);
     });
 
+    it('replaces return type with id for covariantTypes in implementation file', function() {
+      const fileToRender:Code.File = {
+        name: 'RMSomeValue',
+        type: Code.FileType.ObjectiveC(),
+        imports:[
+          {file:'RMSomeValue.h', isPublic:false, library:Maybe.Nothing<string>()}
+        ],
+        enumerations:[],
+        blockTypes:[],
+        comments:[],
+        staticConstants:[],
+        forwardDeclarations:[],
+        functions:[],
+        diagnosticIgnores:[],
+        classes: [
+          {
+            baseClassName:'NSObject',
+            covariantTypes:['ObjectType'],
+            classMethods: [
+              {
+                preprocessors:[],
+                belongsToProtocol:Maybe.Nothing<string>(),
+                code:[
+                  'return [[RMSomeValue alloc] init];'
+                ],
+                comments: [],
+                compilerAttributes:[],
+                keywords: [
+                  {
+                    name:'someClassMethodWithValue1',
+                    argument:Maybe.Just({
+                      name:'value1',
+                      modifiers: [],
+                      type: {
+                        name:'RMSomething',
+                        reference:'RMSomething *'
+                      }
+                    })
+                  },
+                  {
+                    name:'value2',
+                    argument:Maybe.Just({
+                      name:'value2',
+                      modifiers: [],
+                      type: {
+                        name:'RMSomething',
+                        reference:'RMSomething *'
+                      }
+                    })
+                  }
+                ],
+                returnType:{
+                  type:Maybe.Just({
+                    name:'ObjectType',
+                    reference:'ObjectType'
+                  }),
+                  modifiers:[]
+                }
+              }
+            ],
+            comments:[],
+            instanceMethods: [],
+            name:'RMSomeValue',
+            properties: [],
+            internalProperties:[],
+            implementedProtocols: [],
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
+          }
+        ],
+        structs: [],
+        namespaces:[],
+      };
+
+      const renderedOutput:Maybe.Maybe<string> = ObjCRenderer.renderImplementation(fileToRender);
+
+      const expectedOutput:Maybe.Maybe<string> = Maybe.Just<string>(
+        '#if  ! __has_feature(objc_arc)\n' +
+        '#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).\n' +
+        '#endif\n\n' +
+        '#import "RMSomeValue.h"\n' +
+        '\n' +
+        '@implementation RMSomeValue\n' +
+        '\n' +
+        '+ (id)someClassMethodWithValue1:(RMSomething *)value1 value2:(RMSomething *)value2\n' +
+        '{\n' +
+        '  return [[RMSomeValue alloc] init];\n' +
+        '}\n' +
+        '\n\n\n' +
+        '@end\n' +
+        '\n'
+      );
+
+      expect(renderedOutput).toEqualJSON(expectedOutput);
+    });
+
+    it('replaces parameter type with id for covariantTypes in implementation file', function() {
+      const fileToRender:Code.File = {
+        name: 'RMSomeValue',
+        type: Code.FileType.ObjectiveC(),
+        imports:[
+          {file:'RMSomeValue.h', isPublic:false, library:Maybe.Nothing<string>()}
+        ],
+        enumerations:[],
+        blockTypes:[],
+        comments:[],
+        staticConstants:[],
+        forwardDeclarations:[],
+        functions:[],
+        diagnosticIgnores:[],
+        classes: [
+          {
+            baseClassName:'NSObject',
+            covariantTypes:['KeyType', 'ValueType'],
+            classMethods: [],
+            comments:[],
+            instanceMethods: [
+              {
+                preprocessors:[],
+                belongsToProtocol:Maybe.Nothing<string>(),
+                code:[
+                  'return [[RMSomeValue alloc] init];'
+                ],
+                comments: [],
+                compilerAttributes:[],
+                keywords: [
+                  {
+                    name:'objectForKey',
+                    argument:Maybe.Just({
+                      name:'key',
+                      modifiers: [],
+                      type: {
+                        name:'KeyType',
+                        reference:'KeyType'
+                      }
+                    })
+                  }
+                ],
+                returnType:{
+                  type:Maybe.Just({
+                    name:'ValueType',
+                    reference:'ValueType'
+                  }),
+                  modifiers:[]
+                }
+              }
+            ],
+            name:'RMSomeValue',
+            properties: [],
+            internalProperties:[],
+            implementedProtocols: [],
+            nullability: ObjC.ClassNullability.default,
+            subclassingRestricted: false,
+          }
+        ],
+        structs: [],
+        namespaces:[],
+      };
+
+      const renderedOutput:Maybe.Maybe<string> = ObjCRenderer.renderImplementation(fileToRender);
+
+      const expectedOutput:Maybe.Maybe<string> = Maybe.Just<string>(
+        '#if  ! __has_feature(objc_arc)\n' +
+        '#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).\n' +
+        '#endif\n\n' +
+        '#import "RMSomeValue.h"\n' +
+        '\n' +
+        '@implementation RMSomeValue\n' +
+        '\n' +
+        '- (id)objectForKey:(id)key\n' +
+        '{\n' +
+        '  return [[RMSomeValue alloc] init];\n' +
+        '}\n' +
+        '\n' +
+        '@end\n' +
+        '\n'
+      );
+
+      expect(renderedOutput).toEqualJSON(expectedOutput);
+    });
+
     it('renders a class file which contains enumerations', function() {
       const fileToRender:Code.File = {
         name: 'RMSomeValue',
@@ -3185,7 +3536,7 @@ describe('ObjCRenderer', function() {
           reference:'RMSomething *'
         }
       };
-      const argumentString:string = ObjCRenderer.toKeywordArgumentString(keywordArgument);
+      const argumentString:string = ObjCRenderer.toKeywordArgumentString([], keywordArgument);
       const expectedArgumentString:string = ':(RMSomething *)value1';
       expect(argumentString).toEqualJSON(expectedArgumentString);
     });
@@ -3199,7 +3550,7 @@ describe('ObjCRenderer', function() {
           reference:'RMSomething *'
         }
       };
-      const argumentString:string = ObjCRenderer.toKeywordArgumentString(keywordArgument);
+      const argumentString:string = ObjCRenderer.toKeywordArgumentString([], keywordArgument);
       const expectedArgumentString:string = ':(nonnull RMSomething *)value1';
       expect(argumentString).toEqualJSON(expectedArgumentString);
     });
@@ -3213,8 +3564,22 @@ describe('ObjCRenderer', function() {
           reference:'RMSomething *'
         }
       };
-      const argumentString:string = ObjCRenderer.toKeywordArgumentString(keywordArgument);
+      const argumentString:string = ObjCRenderer.toKeywordArgumentString([], keywordArgument);
       const expectedArgumentString:string = ':(nullable RMSomething *)value1';
+      expect(argumentString).toEqualJSON(expectedArgumentString);
+    });
+
+    it('outputs an argument string with a generic replaced by id', function() {
+      const keywordArgument:ObjC.KeywordArgument = {
+        name:'value1',
+        modifiers: [],
+        type: {
+          name:'ObjectType',
+          reference:'ObjectType *'
+        }
+      };
+      const argumentString:string = ObjCRenderer.toKeywordArgumentString(['ObjectType'], keywordArgument);
+      const expectedArgumentString:string = ':(id)value1';
       expect(argumentString).toEqualJSON(expectedArgumentString);
     });
   });

--- a/src/__tests__/plugins/builder-test.ts
+++ b/src/__tests__/plugins/builder-test.ts
@@ -70,6 +70,7 @@ describe('Plugins.Builder', function() {
           classes: [
             {
               baseClassName:'NSObject',
+              covariantTypes:[],
               classMethods: [
                 {
                   preprocessors:[],
@@ -204,6 +205,7 @@ describe('Plugins.Builder', function() {
           classes: [
             {
               baseClassName:'NSObject',
+              covariantTypes:[],
               classMethods: [
                 {
                   preprocessors:[],
@@ -387,6 +389,7 @@ describe('Plugins.Builder', function() {
           classes: [
             {
               baseClassName:'NSObject',
+              covariantTypes:[],
               classMethods: [
                 {
                   preprocessors:[],
@@ -685,6 +688,7 @@ describe('Plugins.Builder', function() {
           classes: [
             {
               baseClassName:'NSObject',
+              covariantTypes:[],
               classMethods: [
                 {
                   preprocessors:[],

--- a/src/__tests__/value-object-creation-test.ts
+++ b/src/__tests__/value-object-creation-test.ts
@@ -194,6 +194,7 @@ describe('ObjectSpecCreation', function() {
               classes: [
                 {
                   baseClassName:'NSObject',
+                  covariantTypes:[],
                   classMethods: [],
                   instanceMethods: [],
                   name:'FooMore',

--- a/src/objc.ts
+++ b/src/objc.ts
@@ -387,6 +387,7 @@ export interface Property {
 
 export interface Class {
   baseClassName:string;
+  covariantTypes:string[];
   classMethods:Method[];
   comments:Comment[];
   instanceMethods:Method[];

--- a/src/pluggable-objc-file-creation.ts
+++ b/src/pluggable-objc-file-creation.ts
@@ -228,6 +228,7 @@ function classFileCreationFunctionWithBaseClassAndPlugins<T>(baseClassName:strin
         classes: [
         {
           baseClassName:baseClassName,
+          covariantTypes:[],
           comments:ObjCCommentUtils.commentsAsBlockFromStringArray(comments),
           classMethods: List.foldl<ObjCGenerationPlugIn<T>, ObjC.Method[]>(FunctionUtils.pApplyf3(typeInformation, buildClassMethods), [], plugins)
                             .sort(sortInstanceMethodComparitor),

--- a/src/plugins/builder.ts
+++ b/src/plugins/builder.ts
@@ -297,6 +297,7 @@ function builderFileForValueType(objectType:ObjectSpec.Type):Code.File {
     classes: [
       {
         baseClassName:'NSObject',
+        covariantTypes:[],
         classMethods: [
           builderClassMethodForValueType(objectType),
           builderFromExistingObjectClassMethodForValueType(objectType)


### PR DESCRIPTION
This is a resubmit of #10 rebased and fixed for the current master state + comments on the original PR.

This diff adds support in the data model layer & objc renderer to render lightweight generics on Objective-C classes.

Specifically, it does the following:
- Adds a `covariantTypes` field to `ObjC.Class`
- Adds support to render generics in headers as `<__covariant ObjectType>` string
- Adds support to render generic types as `id` in implementation files (return types and parameters)
- Adds 5 new unit tests for the expected behavior

All unit & acceptance tests pass.