### PR TITLE
Add generic matching plugin (Generic matcher using ObjC lightweight metrics)

### DIFF
--- a/features/algebraic-type-matching.feature
+++ b/features/algebraic-type-matching.feature
@@ -191,3 +191,56 @@ Feature: Outputting expected Algebraic Type matching methods
 
       @end
       """
+
+  @announce
+  Scenario: Generating an algebraic type with a generic matcher
+    Given a file named "project/values/SimpleADT.adtValue" with:
+      """
+      SimpleADT includes(GenericMatching) excludes(VoidMatching) {
+        subtypeA
+        subtypeB
+      }
+      """
+    And a file named "project/.algebraicTypeConfig" with:
+      """
+      {
+        "defaultExcludes": [
+          "RMCoding"
+         ]
+      }
+      """
+    When I run `../../bin/generate project`
+    Then the file "project/values/SimpleADTMatcher.h" should contain:
+      """
+      #import <Foundation/Foundation.h>
+      #import "SimpleADT.h"
+
+      __attribute__((objc_subclassing_restricted)) 
+      @interface SimpleADTMatcher<__covariant ObjectType> : NSObject
+
+      typedef ObjectType (^SimpleADTObjectTypeSubtypeAMatchHandler)(void);
+      typedef ObjectType (^SimpleADTObjectTypeSubtypeBMatchHandler)(void);
+
+      + (ObjectType)match:(SimpleADT *)simpleADT subtypeA:(SimpleADTObjectTypeSubtypeAMatchHandler)subtypeAMatchHandler subtypeB:(SimpleADTObjectTypeSubtypeBMatchHandler)subtypeBMatchHandler;
+
+      @end
+      """
+   And the file "project/values/SimpleADTMatcher.m" should contain:
+      """
+      + (id)match:(SimpleADT *)simpleADT subtypeA:(SimpleADTObjectTypeSubtypeAMatchHandler)subtypeAMatchHandler subtypeB:(SimpleADTObjectTypeSubtypeBMatchHandler)subtypeBMatchHandler
+      {
+        __block id result = nil;
+
+        SimpleADTSubtypeAMatchHandler matchSubtypeA = ^(void) {
+          result = subtypeAMatchHandler();
+        };
+
+        SimpleADTSubtypeBMatchHandler matchSubtypeB = ^(void) {
+          result = subtypeBMatchHandler();
+        };
+
+        [simpleADT matchSubtypeA:matchSubtypeA subtypeB:matchSubtypeB];
+
+        return result;
+      }
+      """

--- a/src/__tests__/function-utils-test.ts
+++ b/src/__tests__/function-utils-test.ts
@@ -118,6 +118,21 @@ describe('FunctionUtils', function() {
     });
   });
 
+  describe('#pApply3f4', function() {
+    it('partially applies three parameters to a function with four parameters', function() {
+      const f:(a:string, b:string, c:string, d:string) => string = function(a:string, b:string, c:string, d:string):string {
+        return a + b + c + d;
+      };
+
+      const pf:(c:string) => string = FunctionUtils.pApply3f4('A', 'B', 'C', f);
+
+      const actualVal = pf('D');
+      const expectedVal = 'ABCD';
+
+      expect(actualVal).toEqualJSON(expectedVal);
+    });
+  });
+
   describe('#pApply3f5', function() {
     it('partially applies three parameters to a function with five parameters', function() {
       const f:(a:number, b:number, c:number, d:number, e:number) => number = function(a:number, b:number, c:number, d:number, e:number):number {

--- a/src/__tests__/objc-renderer-test.ts
+++ b/src/__tests__/objc-renderer-test.ts
@@ -1378,6 +1378,7 @@ describe('ObjCRenderer', function() {
             ],
             returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
             isPublic: true,
+            isInlined: false,
             nullability: ObjC.ClassNullability.default
           },
           {
@@ -1398,6 +1399,7 @@ describe('ObjCRenderer', function() {
               reference:'Foo *'
             }), modifiers:[] },
             isPublic: true,
+            isInlined: false,
             nullability: ObjC.ClassNullability.default
           }
         ],
@@ -3306,6 +3308,7 @@ describe('ObjCRenderer', function() {
             ],
             returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
             isPublic: true,
+            isInlined: false,
             nullability: ObjC.ClassNullability.default
           },
           {
@@ -3326,6 +3329,7 @@ describe('ObjCRenderer', function() {
               reference:'Foo *'
             }), modifiers:[] },
             isPublic: false,
+            isInlined: false,
             nullability: ObjC.ClassNullability.default
           }
         ],
@@ -3385,6 +3389,7 @@ describe('ObjCRenderer', function() {
             ],
             returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
             isPublic: true,
+            isInlined: false,
             nullability: ObjC.ClassNullability.default
           }
         ],

--- a/src/__tests__/plugins/algebraic-type-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-matching-test.ts
@@ -14,6 +14,7 @@ import AlgebraicTypeVoidMatching = require('../../plugins/algebraic-type-matchin
 import AlgebraicTypeBoolMatching = require('../../plugins/algebraic-type-matching-bool');
 import AlgebraicTypeIntegerMatching = require('../../plugins/algebraic-type-matching-integer');
 import AlgebraicTypeDoubleMatching = require('../../plugins/algebraic-type-matching-double');
+import AlgebraicTypeGenericMatching = require('../../plugins/algebraic-type-matching-generic');
 import Code = require('../../code');
 import Maybe = require('../../maybe');
 import ObjC = require('../../objc');
@@ -23,72 +24,76 @@ const VoidPlugin = AlgebraicTypeVoidMatching.createAlgebraicTypePlugin();
 const BoolPlugin = AlgebraicTypeBoolMatching.createAlgebraicTypePlugin();
 const IntegerPlugin = AlgebraicTypeIntegerMatching.createAlgebraicTypePlugin();
 const DoublePlugin = AlgebraicTypeDoubleMatching.createAlgebraicTypePlugin();
+const GenericPlugin = AlgebraicTypeGenericMatching.createAlgebraicTypePlugin();
 
-describe('Plugins.AlgebraicTypeVoidMatching', function() {
-  describe('#blockTypes', function() {
-    it('returns block types for matching an algebraic type', function() {
-      const algebraicType:AlgebraicType.Type = {
-        annotations: {},
-        name: 'Test',
-        includes: [],
-        excludes: [],
-        typeLookups:[],
-        libraryName: Maybe.Nothing<string>(),
+function algebraicTestTypeWithTwoSubtypes():AlgebraicType.Type {
+  return {
+    annotations: {},
+    name: 'Test',
+    includes: [],
+    excludes: [],
+    typeLookups:[],
+    libraryName: Maybe.Nothing<string>(),
+    comments: [],
+    subtypes: [
+      AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
+      {
+        name: 'SomeSubtype',
         comments: [],
-        subtypes: [
-          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
-          {
-            name: 'SomeSubtype',
-            comments: [],
-            attributes: [
-              {
-                annotations: {},
-                name: 'someString',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSString',
-                  reference: 'NSString *',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject'),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              },
-              {
-                annotations: {},
-                name: 'someUnsignedInteger',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSUInteger',
-                  reference: 'NSUInteger',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>(),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              }
-            ]
-          }),
-          AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
+        attributes: [
           {
             annotations: {},
-            name: 'singleAttributeSubtype',
-            nullability:ObjC.Nullability.Inherited(),
+            name: 'someString',
             comments: [],
+            nullability:ObjC.Nullability.Inherited(),
             type: {
-              name: 'SingleAttributeType',
-              reference: 'SingleAttributeType *',
+              name: 'NSString',
+              reference: 'NSString *',
               libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
               fileTypeIsDefinedIn: Maybe.Nothing<string>(),
               underlyingType: Maybe.Just<string>('NSObject'),
               conformingProtocol: Maybe.Nothing<string>()
             }
-          })
+          },
+          {
+            annotations: {},
+            name: 'someUnsignedInteger',
+            comments: [],
+            nullability:ObjC.Nullability.Inherited(),
+            type: {
+              name: 'NSUInteger',
+              reference: 'NSUInteger',
+              libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
+              fileTypeIsDefinedIn: Maybe.Nothing<string>(),
+              underlyingType: Maybe.Nothing<string>(),
+              conformingProtocol: Maybe.Nothing<string>()
+            }
+          }
         ]
-      };
+      }),
+      AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
+      {
+        annotations: {},
+        name: 'singleAttributeSubtype',
+        nullability:ObjC.Nullability.Inherited(),
+        comments: [],
+        type: {
+          name: 'SingleAttributeType',
+          reference: 'SingleAttributeType *',
+          libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
+          fileTypeIsDefinedIn: Maybe.Nothing<string>(),
+          underlyingType: Maybe.Just<string>('NSObject'),
+          conformingProtocol: Maybe.Nothing<string>()
+        }
+      })
+    ]
+  };
+}
 
+describe('Plugins.AlgebraicTypeVoidMatching', function() {
+  describe('#blockTypes', function() {
+    it('returns block types for matching an algebraic type', function() {
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
       const blockTypes:ObjC.BlockType[] = VoidPlugin.blockTypes(algebraicType);
 
       const expectedBlockTypes:ObjC.BlockType[] = [
@@ -144,68 +149,7 @@ describe('Plugins.AlgebraicTypeVoidMatching', function() {
 
   describe('#instanceMethods', function() {
     it('returns an instance method for matching the subtypes of an algebraic type', function() {
-      const algebraicType:AlgebraicType.Type = {
-        annotations: {},
-        name: 'Test',
-        includes: [],
-        excludes: [],
-        typeLookups:[],
-        libraryName: Maybe.Nothing<string>(),
-        comments: [],
-        subtypes: [
-          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
-          {
-            name: 'SomeSubtype',
-            comments: [],
-            attributes: [
-              {
-                annotations: {},
-                name: 'someString',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSString',
-                  reference: 'NSString *',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject'),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              },
-              {
-                annotations: {},
-                name: 'someUnsignedInteger',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSUInteger',
-                  reference: 'NSUInteger',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>(),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              }
-            ]
-          }),
-          AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
-          {
-            annotations: {},
-            name: 'singleAttributeSubtype',
-            comments: [],
-            nullability:ObjC.Nullability.Inherited(),
-            type: {
-              name: 'SingleAttributeType',
-              reference: 'SingleAttributeType *',
-              libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-              fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject'),
-              conformingProtocol: Maybe.Nothing<string>()
-            }
-          })
-        ]
-      };
-
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
       const instanceMethods:ObjC.Method[] = VoidPlugin.instanceMethods(algebraicType);
 
       const expectedInstanceMethod:ObjC.Method = {
@@ -264,68 +208,7 @@ describe('Plugins.AlgebraicTypeVoidMatching', function() {
 describe('Plugins.AlgebraicTypeBoolMatching', function() {
   describe('#blockTypes', function() {
     it('returns block types for bool matching an algebraic type', function() {
-      const algebraicType:AlgebraicType.Type = {
-        annotations: {},
-        name: 'Test',
-        includes: [],
-        excludes: [],
-        typeLookups:[],
-        libraryName: Maybe.Nothing<string>(),
-        comments: [],
-        subtypes: [
-          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
-          {
-            name: 'SomeSubtype',
-            comments: [],
-            attributes: [
-              {
-                annotations: {},
-                name: 'someString',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSString',
-                  reference: 'NSString *',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject'),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              },
-              {
-                annotations: {},
-                name: 'someUnsignedInteger',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSUInteger',
-                  reference: 'NSUInteger',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>(),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              }
-            ]
-          }),
-          AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
-          {
-            annotations: {},
-            name: 'singleAttributeSubtype',
-            nullability:ObjC.Nullability.Inherited(),
-            comments: [],
-            type: {
-              name: 'SingleAttributeType',
-              reference: 'SingleAttributeType *',
-              libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-              fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject'),
-              conformingProtocol: Maybe.Nothing<string>()
-            }
-          })
-        ]
-      };
-
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
       const blockTypes:ObjC.BlockType[] = BoolPlugin.blockTypes(algebraicType);
 
       const expectedBlockTypes:ObjC.BlockType[] = [
@@ -393,68 +276,7 @@ describe('Plugins.AlgebraicTypeBoolMatching', function() {
 
   describe('#instanceMethods', function() {
     it('returns an instance method for bool matching the subtypes of an algebraic type', function() {
-      const algebraicType:AlgebraicType.Type = {
-        annotations: {},
-        name: 'Test',
-        includes: [],
-        excludes: [],
-        typeLookups:[],
-        libraryName: Maybe.Nothing<string>(),
-        comments: [],
-        subtypes: [
-          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
-          {
-            name: 'SomeSubtype',
-            comments: [],
-            attributes: [
-              {
-                annotations: {},
-                name: 'someString',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSString',
-                  reference: 'NSString *',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject'),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              },
-              {
-                annotations: {},
-                name: 'someUnsignedInteger',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSUInteger',
-                  reference: 'NSUInteger',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>(),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              }
-            ]
-          }),
-          AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
-          {
-            annotations: {},
-            name: 'singleAttributeSubtype',
-            comments: [],
-            nullability:ObjC.Nullability.Inherited(),
-            type: {
-              name: 'SingleAttributeType',
-              reference: 'SingleAttributeType *',
-              libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-              fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject'),
-              conformingProtocol: Maybe.Nothing<string>()
-            }
-          })
-        ]
-      };
-
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
       const instanceMethods:ObjC.Method[] = BoolPlugin.instanceMethods(algebraicType);
 
       const expectedInstanceMethod:ObjC.Method = {
@@ -521,68 +343,7 @@ describe('Plugins.AlgebraicTypeBoolMatching', function() {
 describe('Plugins.AlgebraicTypeIntegerMatching', function() {
   describe('#blockTypes', function() {
     it('returns block types for integer matching an algebraic type', function() {
-      const algebraicType:AlgebraicType.Type = {
-        annotations: {},
-        name: 'Test',
-        includes: [],
-        excludes: [],
-        typeLookups:[],
-        libraryName: Maybe.Nothing<string>(),
-        comments: [],
-        subtypes: [
-          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
-          {
-            name: 'SomeSubtype',
-            comments: [],
-            attributes: [
-              {
-                annotations: {},
-                name: 'someString',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSString',
-                  reference: 'NSString *',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject'),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              },
-              {
-                annotations: {},
-                name: 'someUnsignedInteger',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSUInteger',
-                  reference: 'NSUInteger',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>(),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              }
-            ]
-          }),
-          AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
-          {
-            annotations: {},
-            name: 'singleAttributeSubtype',
-            nullability:ObjC.Nullability.Inherited(),
-            comments: [],
-            type: {
-              name: 'SingleAttributeType',
-              reference: 'SingleAttributeType *',
-              libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-              fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject'),
-              conformingProtocol: Maybe.Nothing<string>()
-            }
-          })
-        ]
-      };
-
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
       const blockTypes:ObjC.BlockType[] = IntegerPlugin.blockTypes(algebraicType);
 
       const expectedBlockTypes:ObjC.BlockType[] = [
@@ -650,68 +411,7 @@ describe('Plugins.AlgebraicTypeIntegerMatching', function() {
 
   describe('#instanceMethods', function() {
     it('returns an instance method for integer matching the subtypes of an algebraic type', function() {
-      const algebraicType:AlgebraicType.Type = {
-        annotations: {},
-        name: 'Test',
-        includes: [],
-        excludes: [],
-        typeLookups:[],
-        libraryName: Maybe.Nothing<string>(),
-        comments: [],
-        subtypes: [
-          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
-          {
-            name: 'SomeSubtype',
-            comments: [],
-            attributes: [
-              {
-                annotations: {},
-                name: 'someString',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSString',
-                  reference: 'NSString *',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject'),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              },
-              {
-                annotations: {},
-                name: 'someUnsignedInteger',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSUInteger',
-                  reference: 'NSUInteger',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>(),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              }
-            ]
-          }),
-          AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
-          {
-            annotations: {},
-            name: 'singleAttributeSubtype',
-            comments: [],
-            nullability:ObjC.Nullability.Inherited(),
-            type: {
-              name: 'SingleAttributeType',
-              reference: 'SingleAttributeType *',
-              libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-              fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject'),
-              conformingProtocol: Maybe.Nothing<string>()
-            }
-          })
-        ]
-      };
-
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
       const instanceMethods:ObjC.Method[] = IntegerPlugin.instanceMethods(algebraicType);
 
       const expectedInstanceMethod:ObjC.Method = {
@@ -778,68 +478,7 @@ describe('Plugins.AlgebraicTypeIntegerMatching', function() {
 describe('Plugins.AlgebraicTypeDoubleMatching', function() {
   describe('#blockTypes', function() {
     it('returns block types for double matching an algebraic type', function() {
-      const algebraicType:AlgebraicType.Type = {
-        annotations: {},
-        name: 'Test',
-        includes: [],
-        excludes: [],
-        typeLookups:[],
-        libraryName: Maybe.Nothing<string>(),
-        comments: [],
-        subtypes: [
-          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
-          {
-            name: 'SomeSubtype',
-            comments: [],
-            attributes: [
-              {
-                annotations: {},
-                name: 'someString',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSString',
-                  reference: 'NSString *',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject'),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              },
-              {
-                annotations: {},
-                name: 'someUnsignedInteger',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSUInteger',
-                  reference: 'NSUInteger',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>(),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              }
-            ]
-          }),
-          AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
-          {
-            annotations: {},
-            name: 'singleAttributeSubtype',
-            nullability:ObjC.Nullability.Inherited(),
-            comments: [],
-            type: {
-              name: 'SingleAttributeType',
-              reference: 'SingleAttributeType *',
-              libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-              fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject'),
-              conformingProtocol: Maybe.Nothing<string>()
-            }
-          })
-        ]
-      };
-
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
       const blockTypes:ObjC.BlockType[] = DoublePlugin.blockTypes(algebraicType);
 
       const expectedBlockTypes:ObjC.BlockType[] = [
@@ -907,68 +546,7 @@ describe('Plugins.AlgebraicTypeDoubleMatching', function() {
 
   describe('#instanceMethods', function() {
     it('returns an instance method for double matching the subtypes of an algebraic type', function() {
-      const algebraicType:AlgebraicType.Type = {
-        annotations: {},
-        name: 'Test',
-        includes: [],
-        excludes: [],
-        typeLookups:[],
-        libraryName: Maybe.Nothing<string>(),
-        comments: [],
-        subtypes: [
-          AlgebraicType.Subtype.NamedAttributeCollectionDefinition(
-          {
-            name: 'SomeSubtype',
-            comments: [],
-            attributes: [
-              {
-                annotations: {},
-                name: 'someString',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSString',
-                  reference: 'NSString *',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Just<string>('NSObject'),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              },
-              {
-                annotations: {},
-                name: 'someUnsignedInteger',
-                comments: [],
-                nullability:ObjC.Nullability.Inherited(),
-                type: {
-                  name: 'NSUInteger',
-                  reference: 'NSUInteger',
-                  libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-                  underlyingType: Maybe.Nothing<string>(),
-                  conformingProtocol: Maybe.Nothing<string>()
-                }
-              }
-            ]
-          }),
-          AlgebraicType.Subtype.SingleAttributeSubtypeDefinition(
-          {
-            annotations: {},
-            name: 'singleAttributeSubtype',
-            comments: [],
-            nullability:ObjC.Nullability.Inherited(),
-            type: {
-              name: 'SingleAttributeType',
-              reference: 'SingleAttributeType *',
-              libraryTypeIsDefinedIn: Maybe.Nothing<string>(),
-              fileTypeIsDefinedIn: Maybe.Nothing<string>(),
-              underlyingType: Maybe.Just<string>('NSObject'),
-              conformingProtocol: Maybe.Nothing<string>()
-            }
-          })
-        ]
-      };
-
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
       const instanceMethods:ObjC.Method[] = DoublePlugin.instanceMethods(algebraicType);
 
       const expectedInstanceMethod:ObjC.Method = {
@@ -1028,6 +606,158 @@ describe('Plugins.AlgebraicTypeDoubleMatching', function() {
       };
 
       expect(instanceMethods).toContain(expectedInstanceMethod);
+    });
+  });
+});
+
+describe('Plugins.AlgebraicTypeGenericMatching', function() {
+  describe('#newFile', function() {
+    it('returns a new matching file for algebraic type', function() {
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
+      const actualFilename = GenericPlugin.additionalFiles(algebraicType)[0].name;
+      expect(actualFilename).toEqual('TestMatcher');
+    });
+  });
+
+  describe('#blockTypes', function() {
+    it('returns block types in additional file for generic matching an algebraic type', function() {
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
+      const blockTypes:ObjC.BlockType[] = GenericPlugin.additionalFiles(algebraicType)[0].blockTypes;
+
+      const expectedBlockTypes:ObjC.BlockType[] = [
+        {
+          comments: [],
+          name: 'TestObjectTypeSomeSubtypeMatchHandler',
+          parameters: [
+            {
+              name: 'someString',
+              type: {
+                name: 'NSString',
+                reference:'NSString *'
+              },
+              nullability: ObjC.Nullability.Inherited()
+            },
+            {
+              name: 'someUnsignedInteger',
+              type: {
+                name: 'NSUInteger',
+                reference:'NSUInteger'
+              },
+              nullability: ObjC.Nullability.Inherited()
+            }
+          ],
+          returnType:{
+            type:Maybe.Just<ObjC.Type>({
+              name: 'ObjectType',
+              reference: 'ObjectType'
+            }), 
+            modifiers:[]
+          },
+          isPublic: true,
+          isInlined: true,
+          nullability: ObjC.ClassNullability.default
+        },
+        {
+          comments: [],
+          name: 'TestObjectTypeSingleAttributeSubtypeMatchHandler',
+          parameters: [
+            {
+              name: 'singleAttributeSubtype',
+              type: {
+                name: 'SingleAttributeType',
+                reference: 'SingleAttributeType *'
+              },
+              nullability: ObjC.Nullability.Inherited()
+            }
+          ],
+          returnType:{
+            type:Maybe.Just<ObjC.Type>({
+              name: 'ObjectType',
+              reference: 'ObjectType'
+            }), 
+            modifiers:[]
+          },
+          isPublic: true,
+          isInlined: true,
+          nullability: ObjC.ClassNullability.default
+        }
+      ];
+
+      expect(blockTypes).toEqualJSON(expectedBlockTypes);
+    });
+  });
+
+  describe('#classMethods', function() {
+    it('returns a class method for generic algebraic type matching', function() {
+      const algebraicType:AlgebraicType.Type = algebraicTestTypeWithTwoSubtypes();
+      const instanceMethods:ObjC.Method[] = GenericPlugin.instanceMethods(algebraicType);
+      const classMethods = GenericPlugin.additionalFiles(algebraicType)[0].classes[0].classMethods;
+
+      const expectedClassMethod:ObjC.Method = {
+        preprocessors:[],
+        belongsToProtocol:Maybe.Nothing<string>(),
+        code: [
+          '__block id result = nil;',
+          '',
+          'TestSomeSubtypeMatchHandler matchSomeSubtype = ^(NSString *someString, NSUInteger someUnsignedInteger) {',
+          '  result = someSubtypeMatchHandler(someString, someUnsignedInteger);',
+          '};',
+          '',
+          'TestSingleAttributeSubtypeMatchHandler matchSingleAttributeSubtype = ^(SingleAttributeType *singleAttributeSubtype) {',
+          '  result = singleAttributeSubtypeMatchHandler(singleAttributeSubtype);',
+          '};',
+          '',
+          '[test matchSomeSubtype:matchSomeSubtype singleAttributeSubtype:matchSingleAttributeSubtype];',
+          '',
+          'return result;'
+        ],
+        compilerAttributes:[],
+        comments: [],
+        keywords: [
+          {
+            name: 'match',
+            argument: Maybe.Just<ObjC.KeywordArgument>({
+              name: 'test',
+              modifiers: [],
+              type: {
+                name: 'Test',
+                reference:'Test*'
+              }
+            })
+          },
+          {
+            name: 'someSubtype',
+            argument: Maybe.Just<ObjC.KeywordArgument>({
+              name: 'someSubtypeMatchHandler',
+              modifiers: [],
+              type: {
+                name: 'TestObjectTypeSomeSubtypeMatchHandler',
+                reference:'TestObjectTypeSomeSubtypeMatchHandler'
+              }
+            })
+          },
+          {
+            name: 'singleAttributeSubtype',
+            argument: Maybe.Just<ObjC.KeywordArgument>({
+              name: 'singleAttributeSubtypeMatchHandler',
+              modifiers: [],
+              type: {
+                name: 'TestObjectTypeSingleAttributeSubtypeMatchHandler',
+                reference:'TestObjectTypeSingleAttributeSubtypeMatchHandler'
+              }
+            })
+          }
+        ],
+        returnType:{
+          type:Maybe.Just<ObjC.Type>({
+            name: 'ObjectType',
+            reference: 'ObjectType'
+          }), 
+          modifiers:[]
+        },
+      };
+
+      expect(classMethods).toContain(expectedClassMethod);
     });
   });
 });

--- a/src/__tests__/plugins/algebraic-type-matching-test.ts
+++ b/src/__tests__/plugins/algebraic-type-matching-test.ts
@@ -115,6 +115,7 @@ describe('Plugins.AlgebraicTypeVoidMatching', function() {
           ],
           returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
           isPublic: true,
+          isInlined: false,
           nullability: ObjC.ClassNullability.default
         },
         {
@@ -132,6 +133,7 @@ describe('Plugins.AlgebraicTypeVoidMatching', function() {
           ],
           returnType:{ type:Maybe.Nothing<ObjC.Type>(), modifiers:[] },
           isPublic: true,
+          isInlined: false,
           nullability: ObjC.ClassNullability.default
         }
       ];
@@ -356,6 +358,7 @@ describe('Plugins.AlgebraicTypeBoolMatching', function() {
             modifiers:[]
           },
           isPublic: true,
+          isInlined: false,
           nullability: ObjC.ClassNullability.default
         },
         {
@@ -379,6 +382,7 @@ describe('Plugins.AlgebraicTypeBoolMatching', function() {
             modifiers:[]
           },
           isPublic: true,
+          isInlined: false,
           nullability: ObjC.ClassNullability.default
         }
       ];
@@ -611,6 +615,7 @@ describe('Plugins.AlgebraicTypeIntegerMatching', function() {
             modifiers:[]
           },
           isPublic: true,
+          isInlined: false,
           nullability: ObjC.ClassNullability.default
         },
         {
@@ -634,6 +639,7 @@ describe('Plugins.AlgebraicTypeIntegerMatching', function() {
             modifiers:[]
           },
           isPublic: true,
+          isInlined: false,
           nullability: ObjC.ClassNullability.default
         }
       ];
@@ -866,6 +872,7 @@ describe('Plugins.AlgebraicTypeDoubleMatching', function() {
             modifiers:[]
           },
           isPublic: true,
+          isInlined: false,
           nullability: ObjC.ClassNullability.default
         },
         {
@@ -889,6 +896,7 @@ describe('Plugins.AlgebraicTypeDoubleMatching', function() {
             modifiers:[]
           },
           isPublic: true,
+          isInlined: false,
           nullability: ObjC.ClassNullability.default
         }
       ];

--- a/src/algebraic-type-utils-for-matching.ts
+++ b/src/algebraic-type-utils-for-matching.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import AlgebraicType = require('./algebraic-type');
+import AlgebraicTypeUtils = require('./algebraic-type-utils');
+import Maybe = require('./maybe');
+import ObjC = require('./objc');
+import ObjCRenderer = require('./objc-renderer');
+import StringUtils = require('./string-utils');
+
+function localFunctionBlockDefinitionNameForSubtype(subtype:AlgebraicType.Subtype):string {
+  return 'match' + StringUtils.capitalize(AlgebraicTypeUtils.subtypeNameFromSubtype(subtype));
+}
+
+function matchBlockNameForSubtype(subtype:AlgebraicType.Subtype):string {
+  return StringUtils.lowercased(AlgebraicTypeUtils.subtypeNameFromSubtype(subtype)) + 'MatchHandler';
+}
+
+function nameOfBlockTypeParameter(parameter:ObjC.BlockTypeParameter):string {
+  return parameter.name;
+}
+
+function keywordForInvokingMatchMethodForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype, index:number):ObjC.Keyword {
+  if (index === 0) {
+    return AlgebraicTypeUtils.firstKeywordForMatchMethodFromSubtype(algebraicType, Maybe.Nothing<AlgebraicTypeUtils.MatchingBlockType>(), subtype);
+  } else {
+    return AlgebraicTypeUtils.keywordForMatchMethodFromSubtype(algebraicType, Maybe.Nothing<AlgebraicTypeUtils.MatchingBlockType>(), subtype);
+  }
+}
+
+export function buildLocalFunctionBlockDefinitionsForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype, blockInvocationWrapper:(blockInvocation:string) => string):string[] {
+  const blockType:ObjC.BlockType = AlgebraicTypeUtils.blockTypeForSubtype(algebraicType, Maybe.Nothing<AlgebraicTypeUtils.MatchingBlockType>(), false, subtype);
+  const start:string = blockType.name + ' ' + localFunctionBlockDefinitionNameForSubtype(subtype) + ' = ^(' + blockType.parameters.map(ObjCRenderer.toBlockTypeParameterString).join(', ') + ') {';
+  const blockBody:string = blockInvocationWrapper(matchBlockNameForSubtype(subtype) + '(' + blockType.parameters.map(nameOfBlockTypeParameter).join(', ') + ')');
+  const end:string[] = ['};', ''];
+  const blockCode:string[] = [start].concat(StringUtils.indent(2)(blockBody)).concat(end);
+  return blockCode;
+}
+
+export function buildKeywordPartsForInvokingMatchMethodForSubtype(algebraicType:AlgebraicType.Type, soFar:string[], subtype:AlgebraicType.Subtype, index:number):string[] {
+  const keyword:ObjC.Keyword = keywordForInvokingMatchMethodForSubtype(algebraicType, subtype, index);
+  const code:string = keyword.name + ':' + localFunctionBlockDefinitionNameForSubtype(subtype);
+  return soFar.concat(code);
+}

--- a/src/algebraic-type-utils.ts
+++ b/src/algebraic-type-utils.ts
@@ -148,7 +148,7 @@ function blockParametersForSubtype(subtype:AlgebraicType.Subtype):ObjC.BlockType
   }
 }
 
-function returnTypeForMatchingBlockType(matchingBlockType:Maybe.Maybe<MatchingBlockType>):ObjC.ReturnType {
+export function returnTypeForMatchingBlockType(matchingBlockType:Maybe.Maybe<MatchingBlockType>):ObjC.ReturnType {
   return Maybe.match(function Just(matchingBlockType:MatchingBlockType) {
                        return {
                          type: Maybe.Just<ObjC.Type>(typeForUnderlyingType(matchingBlockType.underlyingType)),
@@ -164,13 +164,14 @@ function returnTypeForMatchingBlockType(matchingBlockType:Maybe.Maybe<MatchingBl
                      matchingBlockType);
 }
 
-export function blockTypeForSubtype(algebraicType:AlgebraicType.Type, matchingBlockType:Maybe.Maybe<MatchingBlockType>, subtype:AlgebraicType.Subtype):ObjC.BlockType {
+export function blockTypeForSubtype(algebraicType:AlgebraicType.Type, matchingBlockType:Maybe.Maybe<MatchingBlockType>, isInlined:boolean, subtype:AlgebraicType.Subtype):ObjC.BlockType {
   return {
     comments: [],
     name: blockTypeNameForSubtype(algebraicType, subtype, matchingBlockType),
     parameters: blockParametersForSubtype(subtype),
     returnType: returnTypeForMatchingBlockType(matchingBlockType),
     isPublic: true,
+    isInlined: isInlined,
     nullability: algebraicType.includes.indexOf('RMAssumeNonnull') >= 0 ? ObjC.ClassNullability.assumeNonnull : ObjC.ClassNullability.default 
   };
 }
@@ -180,7 +181,7 @@ export function blockParameterNameForMatchMethodFromSubtype(subtype:AlgebraicTyp
 }
 
 export function keywordForMatchMethodFromSubtype(algebraicType:AlgebraicType.Type, matchingBlockType:Maybe.Maybe<MatchingBlockType>, subtype:AlgebraicType.Subtype):ObjC.Keyword {
-  const blockType:ObjC.BlockType = blockTypeForSubtype(algebraicType, matchingBlockType, subtype);
+  const blockType:ObjC.BlockType = blockTypeForSubtype(algebraicType, matchingBlockType, false, subtype);
   return {
     name: StringUtils.lowercased(subtypeNameFromSubtype(subtype)),
     argument: Maybe.Just({

--- a/src/algebraic-types.ts
+++ b/src/algebraic-types.ts
@@ -68,6 +68,7 @@ const BASE_PLUGINS:List.List<string> = List.of(
   'use-cpp',
   'algebraic-type-matching-bool',
   'algebraic-type-matching-double',
+  'algebraic-type-matching-generic',
   'algebraic-type-matching-integer',
   'algebraic-type-matching-void',
   'algebraic-type-templated-matching'

--- a/src/function-utils.ts
+++ b/src/function-utils.ts
@@ -45,6 +45,10 @@ export function pApply2f4<T,U,V,W,X>(val1:T, val2:U, f:(a:T, b:U, c:V, d:W) => X
   return pApplyf3(val2, pApplyf4(val1, f));
 }
 
+export function pApply3f4<T,U,V,W,Y>(val1:T, val2:U, val3:V, f:(a:T, b:U, c:V, d:W) => Y):(d:W) => Y {
+  return pApplyf2(val3, pApplyf3(val2, pApplyf4(val1, f)));
+}
+
 export function pApply3f5<T,U,V,W,X,Y>(val1:T, val2:U, val3:V, f:(a:T, b:U, c:V, d:W, e:X) => Y):(d:W, e:X) => Y {
   return pApplyf3(val3, pApplyf4(val2, pApplyf5(val1, f)));
 }

--- a/src/objc.ts
+++ b/src/objc.ts
@@ -138,6 +138,7 @@ export interface BlockType {
   parameters:BlockTypeParameter[];
   returnType:ReturnType;
   isPublic:boolean;
+  isInlined:boolean;
   nullability:ClassNullability;
 }
 

--- a/src/plugins/algebraic-type-matching-bool.ts
+++ b/src/plugins/algebraic-type-matching-bool.ts
@@ -31,7 +31,7 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
       return [];
     },
     blockTypes: function(algebraicType:AlgebraicType.Type):ObjC.BlockType[] {
-      return algebraicType.subtypes.map(FunctionUtils.pApply2f3(algebraicType, matchingBlockTypeForPlugin(), AlgebraicTypeUtils.blockTypeForSubtype));
+      return algebraicType.subtypes.map(FunctionUtils.pApply3f4(algebraicType, matchingBlockTypeForPlugin(), false, AlgebraicTypeUtils.blockTypeForSubtype));
     },
     classMethods: function(algebraicType:AlgebraicType.Type):ObjC.Method[] {
       return [];

--- a/src/plugins/algebraic-type-matching-double.ts
+++ b/src/plugins/algebraic-type-matching-double.ts
@@ -31,7 +31,7 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
       return [];
     },
     blockTypes: function(algebraicType:AlgebraicType.Type):ObjC.BlockType[] {
-      return algebraicType.subtypes.map(FunctionUtils.pApply2f3(algebraicType, matchingBlockTypeForPlugin(), AlgebraicTypeUtils.blockTypeForSubtype));
+      return algebraicType.subtypes.map(FunctionUtils.pApply3f4(algebraicType, matchingBlockTypeForPlugin(), false, AlgebraicTypeUtils.blockTypeForSubtype));
     },
     classMethods: function(algebraicType:AlgebraicType.Type):ObjC.Method[] {
       return [];

--- a/src/plugins/algebraic-type-matching-generic.ts
+++ b/src/plugins/algebraic-type-matching-generic.ts
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import AlgebraicType = require('../algebraic-type');
+import AlgebraicTypeUtils = require('../algebraic-type-utils');
+import AlgebraicTypeUtilsForMatching = require('../algebraic-type-utils-for-matching');
+import Code = require('../code');
+import Error = require('../error');
+import FileWriter = require('../file-writer');
+import FunctionUtils = require('../function-utils');
+import Maybe = require('../maybe');
+import ObjC = require('../objc');
+import ObjectGeneration = require('../object-generation');
+import StringUtils = require('../string-utils');
+
+function matchingBlockTypeForPlugin():Maybe.Maybe<AlgebraicTypeUtils.MatchingBlockType> {
+  return Maybe.Just<AlgebraicTypeUtils.MatchingBlockType>({
+    name: 'ObjectType',
+    underlyingType: 'ObjectType',
+    defaultValue: 'nil'
+  });
+}
+
+function fileNameForAlgebraicType(algebraicType:AlgebraicType.Type):string {
+  return algebraicType.name + 'Matcher';
+}
+
+function parameterNameForAlgebraicType(algebraicType:AlgebraicType.Type):string {
+  return StringUtils.lowercased(StringUtils.stringRemovingCapitalizedPrefix(algebraicType.name));
+}
+
+//////// Imports
+
+function genericMatcherImportsForAlgebraicType(algebraicType:AlgebraicType.Type):ObjC.Import[] {
+  return [
+    {file:'Foundation.h', isPublic:true, library:Maybe.Just('Foundation')},
+    {file:algebraicType.name + '.h', isPublic:true, library:algebraicType.libraryName},
+    {file:fileNameForAlgebraicType(algebraicType) + '.h', isPublic:false, library:Maybe.Nothing<string>()}
+  ];
+}
+
+//////// Matching Implementation
+
+function blockInvocationWrapper(blockInvocation:string):string {
+  return 'result = ' + blockInvocation + ';';
+}
+
+function buildLocalFunctionBlockDefinitionsForSubtype(algebraicType:AlgebraicType.Type, soFar:string[], subtype:AlgebraicType.Subtype):string[] {
+  return soFar.concat(AlgebraicTypeUtilsForMatching.buildLocalFunctionBlockDefinitionsForSubtype(algebraicType, subtype, blockInvocationWrapper));
+}
+
+function genericMatchingCodeForAlgebraicType(algebraicType:AlgebraicType.Type):string[] {
+  const localVariableDeclaration:string[] = ['__block id result = nil;', ''];
+  
+  const matchingBlockCode:string[] = algebraicType.subtypes.reduce(FunctionUtils.pApplyf3(algebraicType, buildLocalFunctionBlockDefinitionsForSubtype), []);
+  
+  const keywordPartsForMatchInvocation:string[] = algebraicType.subtypes.reduce(FunctionUtils.pApplyf4(algebraicType, AlgebraicTypeUtilsForMatching.buildKeywordPartsForInvokingMatchMethodForSubtype), []);
+  const matchInvocation:string[] = ['[' + parameterNameForAlgebraicType(algebraicType) + ' ' + keywordPartsForMatchInvocation.join(' ') + '];']
+  
+  const returnStatement:string[] = ['', 'return result;'];
+
+  return localVariableDeclaration.concat(matchingBlockCode).concat(matchInvocation).concat(returnStatement);
+}
+
+//////// Matching Class Method
+
+function firstKeywordForGenericMatchMethod(algebraicType:AlgebraicType.Type):ObjC.Keyword {
+  return {
+    name: 'match',
+    argument: Maybe.Just({
+      name: parameterNameForAlgebraicType(algebraicType),
+      modifiers:[],
+      type: {
+        name: algebraicType.name,
+        reference: algebraicType.name + '*'
+      }
+    })
+  };
+}
+
+function keywordsForGenericAlgebraicTypeMatcher(algebraicType:AlgebraicType.Type, matchingBlockType:Maybe.Maybe<AlgebraicTypeUtils.MatchingBlockType>):ObjC.Keyword[] {
+  const firstKeyword:ObjC.Keyword = firstKeywordForGenericMatchMethod(algebraicType);
+  const subtypeKeywords:ObjC.Keyword[] = algebraicType.subtypes.map(FunctionUtils.pApply2f3(algebraicType, matchingBlockType, AlgebraicTypeUtils.keywordForMatchMethodFromSubtype));
+  return [firstKeyword].concat(subtypeKeywords);
+}
+
+function classMethodForGenericMatchingOfAlgebraicType(algebraicType:AlgebraicType.Type):ObjC.Method {
+  const matchingBlockType:Maybe.Maybe<AlgebraicTypeUtils.MatchingBlockType> = matchingBlockTypeForPlugin();
+  return {
+    preprocessors:[],
+    belongsToProtocol:Maybe.Nothing<string>(),
+    code: genericMatchingCodeForAlgebraicType(algebraicType),
+    comments: [],
+    compilerAttributes:[],
+    keywords: keywordsForGenericAlgebraicTypeMatcher(algebraicType, matchingBlockType),
+    returnType: AlgebraicTypeUtils.returnTypeForMatchingBlockType(matchingBlockType)
+  };
+}
+
+//////// Matcher File / Class
+
+function genericMatchingClassForAlgebraicType(algebraicType:AlgebraicType.Type):ObjC.Class {
+  return {
+    baseClassName:'NSObject',
+    covariantTypes:['ObjectType'],
+    classMethods: [classMethodForGenericMatchingOfAlgebraicType(algebraicType)],
+    comments: [ ],
+    instanceMethods: [],
+    name: fileNameForAlgebraicType(algebraicType),
+    properties: [],
+    internalProperties:[],
+    implementedProtocols: [],
+    nullability:ObjC.ClassNullability.default,
+    subclassingRestricted: true,
+  }
+}
+
+function genericMatchingFileForAlgebraicType(algebraicType:AlgebraicType.Type):Code.File {
+  return {
+    name: fileNameForAlgebraicType(algebraicType),
+    type: Code.FileType.ObjectiveC(),
+    imports: genericMatcherImportsForAlgebraicType(algebraicType),
+    forwardDeclarations: [],
+    comments:[],
+    enumerations: [],
+    blockTypes:algebraicType.subtypes.map(FunctionUtils.pApply3f4(algebraicType, matchingBlockTypeForPlugin(), true, AlgebraicTypeUtils.blockTypeForSubtype)),
+    staticConstants: [],
+    functions:[],
+    classes: [
+      genericMatchingClassForAlgebraicType(algebraicType)
+    ],
+    diagnosticIgnores:[],
+    structs: [],
+    namespaces: []
+  };
+}
+
+export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
+  return {
+    additionalFiles: function(algebraicType:AlgebraicType.Type):Code.File[] {
+      return [genericMatchingFileForAlgebraicType(algebraicType)];
+    },
+    blockTypes: function(algebraicType:AlgebraicType.Type):ObjC.BlockType[] {
+      return [];
+    },
+    classMethods: function(algebraicType:AlgebraicType.Type):ObjC.Method[] {
+      return [];
+    },
+    enumerations: function(algebraicType:AlgebraicType.Type):ObjC.Enumeration[] {
+      return [];
+    },
+    fileTransformation: function(request:FileWriter.Request):FileWriter.Request {
+      return request;
+    },
+    fileType: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<Code.FileType> {
+      return Maybe.Nothing<Code.FileType>();
+    },
+    forwardDeclarations: function(algebraicType:AlgebraicType.Type):ObjC.ForwardDeclaration[] {
+      return [];
+    },
+    functions: function(algebraicType:AlgebraicType.Type):ObjC.Function[] {
+      return [];
+    },
+    headerComments: function(algebraicType:AlgebraicType.Type):ObjC.Comment[] {
+      return [];
+    },
+    implementedProtocols: function(algebraicType:AlgebraicType.Type):ObjC.Protocol[] {
+      return [];
+    },
+    imports: function(algebraicType:AlgebraicType.Type):ObjC.Import[] {
+      return [];
+    },
+    instanceMethods: function(algebraicType:AlgebraicType.Type):ObjC.Method[] {
+      return [];
+    },
+    internalProperties: function(algebraicType:AlgebraicType.Type):ObjC.Property[] {
+      return [];
+    },
+    requiredIncludesToRun: ['GenericMatching'],
+    staticConstants: function(algebraicType:AlgebraicType.Type):ObjC.Constant[] {
+      return [];
+    },
+    validationErrors: function(algebraicType:AlgebraicType.Type):Error.Error[] {
+      return [];
+    },
+    nullability: function(algebraicType:AlgebraicType.Type):Maybe.Maybe<ObjC.ClassNullability> {
+      return Maybe.Nothing<ObjC.ClassNullability>();
+    },
+    subclassingRestricted: function(algebraicType:AlgebraicType.Type):boolean {
+      return false;
+    },
+  };
+}

--- a/src/plugins/algebraic-type-matching-integer.ts
+++ b/src/plugins/algebraic-type-matching-integer.ts
@@ -31,7 +31,7 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
       return [];
     },
     blockTypes: function(algebraicType:AlgebraicType.Type):ObjC.BlockType[] {
-      return algebraicType.subtypes.map(FunctionUtils.pApply2f3(algebraicType, matchingBlockTypeForPlugin(), AlgebraicTypeUtils.blockTypeForSubtype));
+      return algebraicType.subtypes.map(FunctionUtils.pApply3f4(algebraicType, matchingBlockTypeForPlugin(), false, AlgebraicTypeUtils.blockTypeForSubtype));
     },
     classMethods: function(algebraicType:AlgebraicType.Type):ObjC.Method[] {
       return [];

--- a/src/plugins/algebraic-type-matching-void.ts
+++ b/src/plugins/algebraic-type-matching-void.ts
@@ -27,7 +27,7 @@ export function createAlgebraicTypePlugin():AlgebraicType.Plugin {
       return [];
     },
     blockTypes: function(algebraicType:AlgebraicType.Type):ObjC.BlockType[] {
-      return algebraicType.subtypes.map(FunctionUtils.pApply2f3(algebraicType, matchingBlockTypeForPlugin(), AlgebraicTypeUtils.blockTypeForSubtype));
+      return algebraicType.subtypes.map(FunctionUtils.pApply3f4(algebraicType, matchingBlockTypeForPlugin(), false, AlgebraicTypeUtils.blockTypeForSubtype));
     },
     classMethods: function(algebraicType:AlgebraicType.Type):ObjC.Method[] {
       return [];

--- a/src/plugins/algebraic-type-templated-matching.ts
+++ b/src/plugins/algebraic-type-templated-matching.ts
@@ -9,6 +9,7 @@
 
 import AlgebraicType = require('../algebraic-type');
 import AlgebraicTypeUtils = require('../algebraic-type-utils');
+import AlgebraicTypeUtilsForMatching = require('../algebraic-type-utils-for-matching');
 import CPlusPlus = require('../cplusplus');
 import Code = require('../code');
 import Error = require('../error');
@@ -43,35 +44,12 @@ function matcherFunctionParameterForAlgebraicType(algebraicType:AlgebraicType.Ty
   return algebraicType.name + ' *' + matcherFunctionParameterNameForAlgebraicType(algebraicType);
 }
 
-function nameOfBlockTypeParameter(parameter:ObjC.BlockTypeParameter):string {
-  return parameter.name;
-}
-
-function localFunctionBlockDefinitionNameForSubtype(subtype:AlgebraicType.Subtype):string {
-  return 'match' + AlgebraicTypeUtils.subtypeNameFromSubtype(subtype);
+function blockInvocationWrapper(blockInvocation:string):string {
+  return 'result = std::make_shared<T>(' + blockInvocation + ');';
 }
 
 function buildLocalFunctionBlockDefinitionsForSubtype(algebraicType:AlgebraicType.Type, soFar:string[], subtype:AlgebraicType.Subtype):string[] {
-  const blockType:ObjC.BlockType = AlgebraicTypeUtils.blockTypeForSubtype(algebraicType, Maybe.Nothing<AlgebraicTypeUtils.MatchingBlockType>(), subtype);
-  const start:string = blockType.name + ' ' + localFunctionBlockDefinitionNameForSubtype(subtype) + ' = ^(' + blockType.parameters.map(ObjCRenderer.toBlockTypeParameterString).join(', ') + ') {';
-  const blockBody:string = 'result = std::make_shared<T>(' + matchBlockNameForSubtype(subtype) + '(' + blockType.parameters.map(nameOfBlockTypeParameter).join(', ') + '));';
-  const end:string[] = ['};', ''];
-  const blockCode:string[] = [start].concat(StringUtils.indent(2)(blockBody)).concat(end);
-  return soFar.concat(blockCode);
-}
-
-function keywordForInvokingMatchMethodForSubtype(algebraicType:AlgebraicType.Type, subtype:AlgebraicType.Subtype, index:number):ObjC.Keyword {
-  if (index === 0) {
-    return AlgebraicTypeUtils.firstKeywordForMatchMethodFromSubtype(algebraicType, Maybe.Nothing<AlgebraicTypeUtils.MatchingBlockType>(), subtype);
-  } else {
-    return AlgebraicTypeUtils.keywordForMatchMethodFromSubtype(algebraicType, Maybe.Nothing<AlgebraicTypeUtils.MatchingBlockType>(), subtype);
-  }
-}
-
-function buildKeywordPartsForInvokingMatchMethodForSubtype(algebraicType:AlgebraicType.Type, soFar:string[], subtype:AlgebraicType.Subtype, index:number):string[] {
-  const keyword:ObjC.Keyword = keywordForInvokingMatchMethodForSubtype(algebraicType, subtype, index);
-  const code:string = keyword.name + ':' + localFunctionBlockDefinitionNameForSubtype(subtype);
-  return soFar.concat(code);
+  return soFar.concat(AlgebraicTypeUtilsForMatching.buildLocalFunctionBlockDefinitionsForSubtype(algebraicType, subtype, blockInvocationWrapper));
 }
 
 function functionParameterProviderWithAlgebraicTypeFirst(algebraicType:AlgebraicType.Type):string[] {
@@ -90,7 +68,7 @@ function matcherFunctionCodeForAlgebraicType(algebraicType:AlgebraicType.Type, f
 
   const blockCode:string[] = algebraicType.subtypes.reduce(FunctionUtils.pApplyf3(algebraicType, buildLocalFunctionBlockDefinitionsForSubtype), []);
 
-  const keywordPartsForMatchInvocation:string[] = algebraicType.subtypes.reduce(FunctionUtils.pApplyf4(algebraicType, buildKeywordPartsForInvokingMatchMethodForSubtype), []);
+  const keywordPartsForMatchInvocation:string[] = algebraicType.subtypes.reduce(FunctionUtils.pApplyf4(algebraicType, AlgebraicTypeUtilsForMatching.buildKeywordPartsForInvokingMatchMethodForSubtype), []);
   const matchInvocationCode:string = '[' + matcherFunctionParameterName + ' ' + keywordPartsForMatchInvocation.join(' ') +'];';
   const returnCode:string = 'return *result;';
   const functionCode:string[] = [assertionCode, resultDeclaration, ''].concat(blockCode).concat(matchInvocationCode).concat(returnCode);


### PR DESCRIPTION
This new plugin allows you to use lightweight generics to directly return an object from a match call.

For the following type:

```
IGMyType includes(GenericMatching) {
  success
  error {
    NSError *error
    CustomContent *customContent
  }
}
```
we generate this additional file:

```objc
@interface IGMyTypeMatcher<__covariant ObjectType> : NSObject

typedef ObjectType (^IGMyTypeObjectTypeSuccessMatchHandler)(void);
typedef ObjectType (^IGMyTypeObjectTypeErrorMatchHandler)(NSError *error, CustomContent *customContent);

+ (ObjectType)match:(IGMyType *)myType success:(IGMyTypeObjectTypeSuccessMatchHandler)successMatchHandler error:(IGMyTypeObjectTypeErrorMatchHandler)errorMatchHandler;

@end
```

Which can be used like this:

```objc
- (NSString *)descriptionForType:(IGMyType *)type {
    return [IGMyTypeMatcher<NSString *> match:type success:^NSString *{
        return @"objc: SUCCESS!!";
    } error:^NSString *(NSError *error, CustomContent *customContent) {
        return [NSString stringWithFormat:@"objc: ERROR - %@-%@", error, customContent];
    }];
}
```

Compared to the templated cpp version:

```objc
- (NSString *)cppDescriptionForType:(IGMyType *)type {
    return IGMyTypeTMatcher<NSString *>::match(type, ^NSString *__strong{
        return @"cpp: SUCCESS!!";
    }, ^NSString *__strong(NSError *error, CustomContent *customContent) {
        return [NSString stringWithFormat:@"cpp: ERROR - %@-%@", error, customContent];
    });
}
```