### PR TITLE
Output control

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -52,3 +52,4 @@ Maybe.match(function(args) {
   function() {
     console.log('Expected use: ./generate [flags] pathToDirectory');
   }, parsedArgs);
+

--- a/features/output_control.feature
+++ b/features/output_control.feature
@@ -1,0 +1,114 @@
+Feature: Specifying an output directory to put results in
+
+  @announce
+  Scenario: Generating only headers
+    Given a file named "project/values/RMValueTypeHeaderOnly.value" with:
+      """
+      # Simple file
+      RMValueTypeHeaderOnly {
+        BOOL doesUserLike
+        NSString* identifier
+      }
+      """
+    And a file named "project/.valueObjectConfig" with:
+      """
+      { }
+      """
+    When I run `../../bin/generate project --headers-only`
+    Then the file "project/values/RMValueTypeHeaderOnly.h" should contain:
+      """
+      #import <Foundation/Foundation.h>
+
+      /**
+       * Simple file
+       */
+      @interface RMValueTypeHeaderOnly : NSObject <NSCopying>
+
+      @property (nonatomic, readonly) BOOL doesUserLike;
+      @property (nonatomic, readonly, copy) NSString *identifier;
+
+      + (instancetype)new NS_UNAVAILABLE;
+
+      - (instancetype)init NS_UNAVAILABLE;
+
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier NS_DESIGNATED_INITIALIZER;
+
+      @end
+
+      """
+   And the file "project/values/RMValueTypeHeaderOnly.m" should not exist
+
+  @announce
+  Scenario: Generating only implementation
+    Given a file named "project/values/RMValueTypeImplOnly.value" with:
+      """
+      # Simple file
+      RMValueTypeImplOnly {
+        BOOL doesUserLike
+        NSString* identifier
+      }
+      """
+    And a file named "project/.valueObjectConfig" with:
+      """
+      { }
+      """
+    When I run `../../bin/generate project --implementations-only`
+   Then the file "project/values/RMValueTypeImplOnly.m" should contain:
+      """
+      #import "RMValueTypeImplOnly.h"
+
+      @implementation RMValueTypeImplOnly
+
+      - (instancetype)initWithDoesUserLike:(BOOL)doesUserLike identifier:(NSString *)identifier
+      {
+        if ((self = [super init])) {
+          _doesUserLike = doesUserLike;
+          _identifier = [identifier copy];
+        }
+
+        return self;
+      }
+
+      - (id)copyWithZone:(nullable NSZone *)zone
+      {
+        return self;
+      }
+
+      - (NSString *)description
+      {
+        return [NSString stringWithFormat:@"%@ - \n\t doesUserLike: %@; \n\t identifier: %@; \n", [super description], _doesUserLike ? @"YES" : @"NO", _identifier];
+      }
+
+      - (NSUInteger)hash
+      {
+        NSUInteger subhashes[] = {(NSUInteger)_doesUserLike, [_identifier hash]};
+        NSUInteger result = subhashes[0];
+        for (int ii = 1; ii < 2; ++ii) {
+          unsigned long long base = (((unsigned long long)result) << 32 | subhashes[ii]);
+          base = (~base) + (base << 18);
+          base ^= (base >> 31);
+          base *=  21;
+          base ^= (base >> 11);
+          base += (base << 6);
+          base ^= (base >> 22);
+          result = base;
+        }
+        return result;
+      }
+
+      - (BOOL)isEqual:(RMValueTypeImplOnly *)object
+      {
+        if (self == object) {
+          return YES;
+        } else if (object == nil || ![object isKindOfClass:[self class]]) {
+          return NO;
+        }
+        return
+          _doesUserLike == object->_doesUserLike &&
+          (_identifier == object->_identifier ? YES : [_identifier isEqual:object->_identifier]);
+      }
+
+      @end
+
+      """
+   And the file "project/values/RMValueTypeImplOnly.h" should not exist

--- a/src/__tests__/commandline-test.ts
+++ b/src/__tests__/commandline-test.ts
@@ -40,6 +40,8 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -61,6 +63,8 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -82,6 +86,8 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -103,6 +109,8 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -124,6 +132,8 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -145,6 +155,8 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -166,6 +178,8 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -187,6 +201,8 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -208,6 +224,8 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -229,6 +247,8 @@ describe('CommandLine', function() {
         includes:['PluginOne', 'PluginTwo'],
         excludes:['PluginThree'],
         prohibitPluginDirectives:false,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -250,10 +270,23 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:true,
+        headersOnly:false,
+        implOnly:false,
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
     });
+
+
+    it('returns nothing when both --headers-only and implementation-only are passed', function() {
+      const args:string[] = ['--headers-only', '--implementation-only'];
+      const parsedArgs:Maybe.Maybe<CommandLine.Arguments> = CommandLine.parseArgs(args);
+
+      const expectedResult = Maybe.Nothing<CommandLine.Arguments>();
+
+      expect(parsedArgs).toEqualJSON(expectedResult);
+    });
+
 
     it('returns nothing when only --verbose is provided', function() {
       const args:string[] = ['--verbose'];

--- a/src/__tests__/commandline-test.ts
+++ b/src/__tests__/commandline-test.ts
@@ -40,8 +40,11 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -63,8 +66,11 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -86,8 +92,11 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -109,8 +118,11 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -132,8 +144,11 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -155,8 +170,11 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -178,8 +196,11 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -201,8 +222,11 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -224,8 +248,11 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:false,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -247,8 +274,11 @@ describe('CommandLine', function() {
         includes:['PluginOne', 'PluginTwo'],
         excludes:['PluginThree'],
         prohibitPluginDirectives:false,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -270,8 +300,11 @@ describe('CommandLine', function() {
         includes:[],
         excludes:[],
         prohibitPluginDirectives:true,
-        headersOnly:false,
-        implOnly:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
@@ -283,6 +316,60 @@ describe('CommandLine', function() {
       const parsedArgs:Maybe.Maybe<CommandLine.Arguments> = CommandLine.parseArgs(args);
 
       const expectedResult = Maybe.Nothing<CommandLine.Arguments>();
+
+      expect(parsedArgs).toEqualJSON(expectedResult);
+    });
+
+
+    it('includes a list of things to emit', function() {
+      const args:string[] = ['project/to/generate', '--include=PluginOne', '--include=PluginTwo', '--emit=PluginOne', '--emit=object'];
+      const parsedArgs:Maybe.Maybe<CommandLine.Arguments> = CommandLine.parseArgs(args);
+
+      const expectedResult = Maybe.Just<CommandLine.Arguments>({
+        givenPath:'project/to/generate',
+        adtConfigPath:undefined,
+        valueObjectConfigPath:undefined,
+        objectConfigPath:undefined,
+        interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
+        minimalLevel:10,
+        dryRun: false,
+        outputPath:undefined,
+        includes:['PluginOne', 'PluginTwo'],
+        excludes:[],
+        prohibitPluginDirectives:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: ['PluginOne', 'object'],
+        },
+      });
+
+      expect(parsedArgs).toEqualJSON(expectedResult);
+    });
+
+
+    it('emitting "all" ensures empty output list, even if other emit options are present', function() {
+      const args:string[] = ['project/to/generate', '--include=PluginOne', '--include=PluginTwo', '--emit=all', '--emit=foo'];
+      const parsedArgs:Maybe.Maybe<CommandLine.Arguments> = CommandLine.parseArgs(args);
+
+      const expectedResult = Maybe.Just<CommandLine.Arguments>({
+        givenPath:'project/to/generate',
+        adtConfigPath:undefined,
+        valueObjectConfigPath:undefined,
+        objectConfigPath:undefined,
+        interestedLoggingTypes:List.of(Logging.LoggingType.info, Logging.LoggingType.error),
+        minimalLevel:10,
+        dryRun: false,
+        outputPath:undefined,
+        includes:['PluginOne', 'PluginTwo'],
+        excludes:[],
+        prohibitPluginDirectives:false,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
+      });
 
       expect(parsedArgs).toEqualJSON(expectedResult);
     });

--- a/src/__tests__/value-object-creation-test.ts
+++ b/src/__tests__/value-object-creation-test.ts
@@ -117,6 +117,8 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
+        renderHeader:true,
+        renderImpl:true,
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -259,6 +261,8 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
+        renderHeader:true,
+        renderImpl:true,
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -376,6 +380,8 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
+        renderHeader:true,
+        renderImpl:true,
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -508,6 +514,8 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
+        renderHeader:true,
+        renderImpl:true,
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -661,6 +669,8 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
+        renderHeader:true,
+        renderImpl:true,
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -787,6 +797,8 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
+        renderHeader:true,
+        renderImpl:true,
       };
 
       const writeRequest:Either.Either<Error.Error[], FileWriter.FileWriteRequest> = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -925,6 +937,8 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
+        renderHeader:true,
+        renderImpl:true,
       };
 
       const writeRequest:Either.Either<Error.Error[], FileWriter.FileWriteRequest> = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin1, Plugin2));
@@ -1124,6 +1138,8 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
+        renderHeader:true,
+        renderImpl:true,
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin1, Plugin2));
@@ -1373,6 +1389,8 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
+        renderHeader:true,
+        renderImpl:true,
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin1, Plugin2));
@@ -1523,6 +1541,8 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Just<File.AbsoluteFilePath>({absolutePath:'local/path'}),
+        renderHeader:true,
+        renderImpl:true,
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));

--- a/src/__tests__/value-object-creation-test.ts
+++ b/src/__tests__/value-object-creation-test.ts
@@ -18,6 +18,7 @@ import Maybe = require('../maybe');
 import ObjC = require('../objc');
 import ObjectSpec = require('../object-spec');
 import ObjectSpecCreation = require('../object-spec-creation');
+import OutputControl = require('../output-control');
 
 describe('ObjectSpecCreation', function() {
   describe('#fileWriteRequests', function() {
@@ -117,8 +118,11 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
-        renderHeader:true,
-        renderImpl:true,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -261,8 +265,11 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
-        renderHeader:true,
-        renderImpl:true,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -380,8 +387,11 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
-        renderHeader:true,
-        renderImpl:true,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -514,8 +524,11 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
-        renderHeader:true,
-        renderImpl:true,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -669,8 +682,11 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
-        renderHeader:true,
-        renderImpl:true,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -797,8 +813,11 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
-        renderHeader:true,
-        renderImpl:true,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       };
 
       const writeRequest:Either.Either<Error.Error[], FileWriter.FileWriteRequest> = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));
@@ -937,8 +956,11 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
-        renderHeader:true,
-        renderImpl:true,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       };
 
       const writeRequest:Either.Either<Error.Error[], FileWriter.FileWriteRequest> = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin1, Plugin2));
@@ -1138,8 +1160,11 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
-        renderHeader:true,
-        renderImpl:true,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin1, Plugin2));
@@ -1389,8 +1414,11 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Nothing<File.AbsoluteFilePath>(),
-        renderHeader:true,
-        renderImpl:true,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin1, Plugin2));
@@ -1541,8 +1569,11 @@ describe('ObjectSpecCreation', function() {
         path:File.getAbsoluteFilePath('something.value'),
         typeInformation:objectType,
         outputPath:Maybe.Just<File.AbsoluteFilePath>({absolutePath:'local/path'}),
-        renderHeader:true,
-        renderImpl:true,
+        outputFlags: {
+          emitHeaders: true,
+          emitImplementations: true,
+          outputList: [],
+        },
       };
 
       const writeRequest = ObjectSpecCreation.fileWriteRequest(generationRequest, List.of(Plugin));

--- a/src/algebraic-type-creation.ts
+++ b/src/algebraic-type-creation.ts
@@ -97,6 +97,8 @@ function createAlgebraicTypeObjCPlugIn(plugin:AlgebraicType.Plugin) : AlgebraicT
     subclassingRestricted: function(typeInformation:AlgebraicType.Type):boolean {
       return plugin.subclassingRestricted(typeInformation);
     },
+
+    requiredIncludesToRun: plugin.requiredIncludesToRun,
   };
 }
 

--- a/src/algebraic-types.ts
+++ b/src/algebraic-types.ts
@@ -21,6 +21,7 @@ import Logging = require('./logging');
 import LoggingSequenceUtils = require('./logged-sequence-utils');
 import Maybe = require('./maybe');
 import ObjC = require('./objc');
+import OutputControl = require('./output-control');
 import PathUtils = require('./path-utils');
 import PluginInclusionUtils = require('./plugin-inclusion-utils');
 import Promise = require('./promise');
@@ -45,8 +46,7 @@ interface PathAndTypeInfo {
 
 interface GenerationOptions {
   outputPath: Maybe.Maybe<File.AbsoluteFilePath>;
-  renderHeader: boolean;
-  renderImpl: boolean;
+  outputFlags: OutputControl.OutputFlags;
 }
 
 const BASE_INCLUDES:List.List<string> = List.of(
@@ -115,9 +115,8 @@ function processAlgebraicTypeCreationRequest(options: GenerationOptions, future:
             baseClassName:creationContext.baseClassName,
             path:pathAndTypeInfo.path,
             outputPath:options.outputPath,
+            outputFlags:options.outputFlags,
             typeInformation:typeInformationContainingDefaultIncludes(pathAndTypeInfo.typeInformation, creationContext.defaultIncludes),
-            renderHeader:options.renderHeader,
-            renderImpl:options.renderImpl,
           };
 
           return AlgebraicTypeCreation.fileWriteRequest(request, creationContext.plugins);
@@ -194,8 +193,7 @@ export function generate(directoryRunFrom:string, parsedArgs:CommandLine.Argumen
 
     const options: GenerationOptions = {
       outputPath: outputPath,
-      renderHeader: !parsedArgs.implOnly,
-      renderImpl: !parsedArgs.headersOnly,
+      outputFlags: parsedArgs.outputFlags,
     }
 
     const pluginProcessedSequence = LoggingSequenceUtils.mapLoggedSequence(parsedSequence,

--- a/src/objc-file-creation.ts
+++ b/src/objc-file-creation.ts
@@ -41,11 +41,11 @@ function implementationFileExtensionForFileType(fileType:Code.FileType):string {
   });
 }
 
-export function fileCreationRequest(containingFolderPath: File.AbsoluteFilePath, file:Code.File):Either.Either<Error.Error, FileWriter.FileWriteRequest> {
-  const headerContents:Maybe.Maybe<string> = ObjCRenderer.renderHeader(file);
+export function fileCreationRequest(containingFolderPath: File.AbsoluteFilePath, file:Code.File, renderHeader:boolean, renderImpl:boolean):Either.Either<Error.Error, FileWriter.FileWriteRequest> {
+  const headerContents:Maybe.Maybe<string> = renderHeader ? ObjCRenderer.renderHeader(file) : Maybe.Nothing<string>();
   const headerRequest:Maybe.Maybe<FileWriter.Request> = fileRequest(containingFolderPath, fileNameIncludingExtension(file, 'h'), headerContents);
 
-  const implementationContents:Maybe.Maybe<string> = ObjCRenderer.renderImplementation(file);
+  const implementationContents:Maybe.Maybe<string> = renderImpl ? ObjCRenderer.renderImplementation(file) : Maybe.Nothing<string>();
   const implementationRequest:Maybe.Maybe<FileWriter.Request> = fileRequest(containingFolderPath, fileNameIncludingExtension(file, implementationFileExtensionForFileType(file.type)), implementationContents);
 
   const baseRequests:List.List<FileWriter.Request> = List.of<FileWriter.Request>();

--- a/src/object-spec-creation.ts
+++ b/src/object-spec-creation.ts
@@ -97,6 +97,8 @@ function createObjectSpecObjCPlugIn(plugin:ObjectSpec.Plugin) : ObjectSpecObjCPl
     subclassingRestricted: function(typeInformation:ObjectSpec.Type):boolean {
       return plugin.subclassingRestricted(typeInformation);
     },
+
+    requiredIncludesToRun: plugin.requiredIncludesToRun,
   };
 }
 
@@ -171,9 +173,8 @@ export function fileWriteRequest(request:Request, plugins:List.List<ObjectSpec.P
     baseClassName:request.baseClassName,
     path:request.path,
     outputPath:request.outputPath,
+    outputFlags:request.outputFlags,
     typeInformation:typeInformationWithAllAttributesFromPlugins(request.typeInformation, pluginsToRun),
-    renderHeader:request.renderHeader,
-    renderImpl:request.renderImpl
   };
 
   return PluggableObjCFileCreation.fileWriteRequest(requestWithUpdatedType, typeInfoProvider, wrappedPlugins);

--- a/src/object-spec-creation.ts
+++ b/src/object-spec-creation.ts
@@ -171,7 +171,9 @@ export function fileWriteRequest(request:Request, plugins:List.List<ObjectSpec.P
     baseClassName:request.baseClassName,
     path:request.path,
     outputPath:request.outputPath,
-    typeInformation:typeInformationWithAllAttributesFromPlugins(request.typeInformation, pluginsToRun)
+    typeInformation:typeInformationWithAllAttributesFromPlugins(request.typeInformation, pluginsToRun),
+    renderHeader:request.renderHeader,
+    renderImpl:request.renderImpl
   };
 
   return PluggableObjCFileCreation.fileWriteRequest(requestWithUpdatedType, typeInfoProvider, wrappedPlugins);

--- a/src/object-specs.ts
+++ b/src/object-specs.ts
@@ -27,6 +27,7 @@ import Promise = require('./promise');
 import ObjectSpec = require('./object-spec');
 import ObjectSpecCreation = require('./object-spec-creation');
 import ObjectSpecParser = require('./object-spec-parser');
+import OutputControl = require('./output-control');
 import WriteFileUtils = require('./file-logged-sequence-write-utils');
 import path = require('path');
 
@@ -46,8 +47,7 @@ interface PathAndTypeInfo {
 
 interface GenerationOptions {
   outputPath: Maybe.Maybe<File.AbsoluteFilePath>;
-  renderHeader: boolean;
-  renderImpl: boolean;
+  outputFlags: OutputControl.OutputFlags;
 }
 
 function evaluateUnparsedObjectSpecCreationRequest(request:ReadFileUtils.UnparsedObjectCreationRequest):Either.Either<Error.Error[], PathAndTypeInfo> {
@@ -89,9 +89,8 @@ function processObjectSpecCreationRequest(options: GenerationOptions, future:Pro
             baseClassName:creationContext.baseClassName,
             path:pathAndTypeInfo.path,
             outputPath:options.outputPath,
+            outputFlags:options.outputFlags,
             typeInformation:typeInformationContainingDefaultIncludes(pathAndTypeInfo.typeInformation, creationContext.defaultIncludes),
-            renderHeader:options.renderHeader,
-            renderImpl:options.renderImpl
           };
 
           return ObjectSpecCreation.fileWriteRequest(request, creationContext.plugins);
@@ -168,8 +167,7 @@ export function generate(directoryRunFrom:string, extension:string, configFileNa
 
     const options: GenerationOptions = {
       outputPath: outputPath,
-      renderHeader: !parsedArgs.implOnly,
-      renderImpl: !parsedArgs.headersOnly,
+      outputFlags: parsedArgs.outputFlags,
     }
 
     const pluginProcessedSequence = LoggingSequenceUtils.mapLoggedSequence(parsedSequence,

--- a/src/output-control.ts
+++ b/src/output-control.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export interface OutputFlags {
+  emitHeaders: boolean;
+  emitImplementations: boolean;
+  // empty implies emit object and all additional files
+  outputList: string[];
+}
+
+export function ShouldEmitObject(flags:OutputFlags) {
+  return flags.outputList.length == 0 || (flags.outputList.indexOf('object') !== -1);
+}
+
+export function ShouldEmitPluginFile(flags:OutputFlags, pluginName:string) {
+  return flags.outputList.length == 0 || (flags.outputList.indexOf(pluginName) !== -1);
+}


### PR DESCRIPTION
Add two new command-line options: --headers-only and --implementation-only. These allow us to control what is output. I plan to use this in conjunction with --output-path to better fit in with our buck integration. If both files are generated, buck complains that I left something behind. And it's wasteful, so this will allow me to no longer have to use temp directories and output just the file I need. This should speed things up a little.