### PR TITLE
Add nil checks for nonnull coding attributes

### DIFF
--- a/features/coding.feature
+++ b/features/coding.feature
@@ -131,3 +131,56 @@ Feature: Outputting Value Objects With Coded Values
         return self;
       }
       """
+
+  @announce
+  Scenario: Generating nil checks for nonnull properties
+    Given a file named "project/values/RMPage.value" with:
+      """
+      RMPage includes(RMCoding, RMAssumeNonnull) {
+        BOOL primitive
+        NSString* identifier
+        %nullable
+        NSString* nullableIdentifier
+      }
+      """
+    And a file named "project/.valueObjectConfig" with:
+      """
+      { }
+      """
+    When I run `../../bin/generate project`
+    Then the file "project/values/RMPage.h" should contain:
+      """
+      #import <Foundation/Foundation.h>
+
+      NS_ASSUME_NONNULL_BEGIN
+
+      @interface RMPage : NSObject <NSCopying, NSCoding>
+
+      @property (nonatomic, readonly) BOOL primitive;
+      @property (nonatomic, readonly, copy) NSString *identifier;
+      @property (nonatomic, readonly, copy, nullable) NSString *nullableIdentifier;
+
+      + (instancetype)new NS_UNAVAILABLE;
+
+      - (instancetype)init NS_UNAVAILABLE;
+
+      - (instancetype)initWithPrimitive:(BOOL)primitive identifier:(NSString *)identifier nullableIdentifier:(nullable NSString *)nullableIdentifier NS_DESIGNATED_INITIALIZER;
+
+      @end
+
+      NS_ASSUME_NONNULL_END
+
+      """
+   And the file "project/values/RMPage.m" should contain:
+      """
+      - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder
+      {
+        if ((self = [super init])) {
+          _primitive = [aDecoder decodeBoolForKey:kPrimitiveKey];
+          _identifier = [aDecoder decodeObjectForKey:kIdentifierKey];
+          _nullableIdentifier = [aDecoder decodeObjectForKey:kNullableIdentifierKey];
+          if (_identifier == nil) { return nil; }
+        }
+        return self;
+      }
+      """


### PR DESCRIPTION
Remodel's generated `NSCoding` code, especially in combination with `RMAssumeNonnull`, is unsafe because it does not check for `nil` when initializing `nonnull` properties. This leads to instances that lie about their nullability, which is particularly bad when consuming a Remodel class from Swift.

To solve this, I've added `nil` checks in `-initWithCoder:`, and return `nil` from the initializer if any `nonnull` property is `nil`. Currently, this is done for all models, with this logic:

- If a property is explicitly `nonnull`, check.
- If a property is explicitly `nullable`, don't check.
- If a property inherits its nullability, check if `RMAssumeNonnull` is also included.

Some things to discuss:

- Implicit dependency on `RMAssumeNonnull`.
- Affect on real-world codebases: while `-initWithCoder:` returns `nullable instancetype`, so the contract is that it may return `nil`, and we aren't really changing the public API, downstream users may be affected.
- If the former is an issue, some way to make this opt-in? I'd rather not fragment into a second plugin though.

Once these are decided I can add more test cases for variants (no `RMAssumeNonnull`, etc.), just deferring that until these decisions have been made to avoid extra rewrites.