### PR TITLE
Fixed issue #75: Parser rejects comments after %type directives.

### DIFF
--- a/features/algebraic-types.feature
+++ b/features/algebraic-types.feature
@@ -9,6 +9,7 @@ Feature: Outputting Algebraic Types
       %type name=RMSomeObject library=SomeLib file=AnotherFile
       %type name=RMFooObject
       %type name=RMSomeEnum canForwardDeclare=false
+      # What is not to love?!
       SimpleADT {
         # Really good type,
         # always use this
@@ -48,6 +49,7 @@ Feature: Outputting Algebraic Types
 
       /**
        * What a beautiful ADT
+       * What is not to love?!
        */
       @interface SimpleADT : NSObject <NSCopying>
 

--- a/features/value_object.feature
+++ b/features/value_object.feature
@@ -11,6 +11,7 @@ Feature: Outputting Value Objects
       %type name=RMFooObject
       %type name=RMSomeEnum canForwardDeclare=false
       %type name=RMSomeType library=FooLibrary
+      # And an extra comment here for good measure.
       RMPage {
         BOOL doesUserLike
         NSString* identifier
@@ -37,6 +38,7 @@ Feature: Outputting Value Objects
       /**
        * Important and gripping comment
        * that takes up two lines.
+       * And an extra comment here for good measure.
        */
       @interface RMPage : NSObject <NSCopying>
 

--- a/src/js/object-mona-parser/algebraic-type/algebraic-type-parser.js
+++ b/src/js/object-mona-parser/algebraic-type/algebraic-type-parser.js
@@ -41,7 +41,7 @@ function algebraicType() {
 
       const foundType = {
         annotations: parsedAnnotations,
-        comments: comments,
+        comments: comments.concat(typeNameSection.comments),
         excludes: excludes,
         includes: includes,
         typeName: typeNameSection.typeName,

--- a/src/js/object-mona-parser/object-parser-common.js
+++ b/src/js/object-mona-parser/object-parser-common.js
@@ -200,11 +200,13 @@ function namedParenSection(sectionName){
 // Name includes(Include) excludes(Exclude)
 function parseTypeNameSectionWithIncludes() {
   return mona.sequence(function(s) {
+    const comments = s(mona.collect(comment()));
     const typeName = s(mona.trim(mona.text(mona.alphanum())));
     const includes = s(mona.maybe(namedParenSection('includes')));
     const excludes = s(mona.maybe(namedParenSection('excludes')));
 
     const typeNameSection = {
+      comments: comments,
       typeName: typeName,
       includes: includes,
       excludes: excludes
@@ -217,10 +219,12 @@ function parseTypeNameSectionWithIncludes() {
 // Name
 function parseTypeNameSectionWithoutIncludes() {
   return mona.sequence(function(s) {
+    const comments = s(mona.collect(comment()));
     s(mona.maybe(mona.spaces()));
     const typeName = s(mona.text(mona.alphanum()));
 
     const typeNameSection = {
+      comments: comments,
       typeName: typeName,
     };
     return mona.value(typeNameSection);
@@ -296,30 +300,23 @@ function parseNamedAttributeGroup(withIncludes) {
 }
 
 function namedAttributeGroupFoundType(comments, parsedAnnotations, typeNameSection, attributes, withIncludes) {
-
-  var foundType;
   if (withIncludes) {
-    const includes = typeNameSection.includes === undefined ? [] : typeNameSection.includes;
-    const excludes = typeNameSection.excludes === undefined ? [] : typeNameSection.excludes;
-
-    foundType = {
+    return {
       annotations: parsedAnnotations,
       attributes: attributes || [],
-      comments: comments,
+      comments: comments.concat(typeNameSection.comments),
       typeName: typeNameSection.typeName,
-      includes: includes,
-      excludes: excludes
+      includes: typeNameSection.includes || [],
+      excludes: typeNameSection.excludes || []
     };
   } else {
-    foundType = {
+    return {
       annotations: parsedAnnotations,
       attributes: attributes || [],
-      comments: comments,
+      comments: comments.concat(typeNameSection.comments),
       typeName: typeNameSection.typeName
     };
   }
-
-  return foundType;
 }
 
 function parseAttributeTypeReferenceSectionWithOptionalPointer() {


### PR DESCRIPTION
Fix to issue #75. We now allow comments after types and merge it with the object comments.